### PR TITLE
[SYCL-BLAS] Initial integration of SYCL-BLAS into oneMKL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 #===============================================================================
 # Copyright 2020-2021 Intel Corporation
 # Copyright (C) 2022 Heidelberg University, Engineering Mathematics and Computing Lab (EMCL) and Computing Centre (URZ)
-# Copyright 2022 Codeplay Software
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 #===============================================================================
 # Copyright 2020-2021 Intel Corporation
 # Copyright (C) 2022 Heidelberg University, Engineering Mathematics and Computing Lab (EMCL) and Computing Centre (URZ)
+# Copyright 2022 Codeplay Software
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,6 +55,7 @@ option(ENABLE_ROCBLAS_BACKEND "" OFF)
 option(ENABLE_CURAND_BACKEND "" OFF)
 option(ENABLE_ROCRAND_BACKEND "" OFF)
 option(ENABLE_NETLIB_BACKEND "" OFF)
+option(ENABLE_SYCLBLAS_BACKEND "" OFF)
 set(ONEMKL_SYCL_IMPLEMENTATION "dpc++" CACHE STRING "Name of the SYCL compiler")
 set(HIP_TARGETS "" CACHE STRING "Target HIP architectures")
 
@@ -72,7 +74,8 @@ if(ENABLE_MKLCPU_BACKEND
         OR ENABLE_MKLGPU_BACKEND
         OR ENABLE_CUBLAS_BACKEND
         OR ENABLE_ROCBLAS_BACKEND
-        OR ENABLE_NETLIB_BACKEND)
+        OR ENABLE_NETLIB_BACKEND
+        OR ENABLE_SYCLBLAS_BACKEND)
   list(APPEND DOMAINS_LIST "blas")
 endif()
 if(ENABLE_MKLCPU_BACKEND

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ oneMKL is part of [oneAPI](https://oneapi.io).
     </thead>
     <tbody>
         <tr>
-            <td rowspan=8 align="center">oneMKL interface</td>
-            <td rowspan=8 align="center">oneMKL selector</td>
+            <td rowspan=9 align="center">oneMKL interface</td>
+            <td rowspan=9 align="center">oneMKL selector</td>
             <td align="center"><a href="https://software.intel.com/en-us/oneapi/onemkl">Intel(R) oneAPI Math Kernel Library</a> for x86 CPU</td>
             <td align="center">x86 CPU</td>
         </tr>
@@ -50,6 +50,10 @@ oneMKL is part of [oneAPI](https://oneapi.io).
         <tr>
             <td align="center"><a href="https://github.com/ROCmSoftwarePlatform/rocRAND"> AMD rocRAND</a> for AMD GPU </td>
             <td align="center">AMD GPU</td>
+        </tr>
+        <tr>
+            <td align="center"><a href="https://github.com/codeplaysoftware/sycl-blas"> SYCL-BLAS </a> for Intel GPU </td>
+            <td align="center">Intel GPU</td>
         </tr>
     </tbody>
 </table>
@@ -140,7 +144,7 @@ Supported domains: BLAS, LAPACK, RNG
     </thead>
     <tbody>
         <tr>
-            <td rowspan=5 align="center">BLAS</td>
+            <td rowspan=6 align="center">BLAS</td>
             <td align="center">x86 CPU</td>
             <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
             <td align="center">Dynamic, Static</td>
@@ -168,6 +172,12 @@ Supported domains: BLAS, LAPACK, RNG
             <td align="center">AMD rocBLAS </td>
             <td align="center">Dynamic, Static</td>
             <td align="center">LLVM*, hipSYCL</td>
+        </tr>
+	    <tr >
+            <td align="center">Intel GPU</td>
+            <td align="center">SYCL-BLAS </td>
+            <td align="center">Dynamic, Static</td>
+            <td align="center">DPC++</td>
         </tr>
         <tr>
             <td rowspan=3 align="center">LAPACK</td>
@@ -228,7 +238,7 @@ Supported domains: BLAS, LAPACK, RNG
     </thead>
     <tbody>
         <tr>
-            <td rowspan=3 align="center">BLAS</td>
+            <td rowspan=4 align="center">BLAS</td>
             <td align="center">x86 CPU</td>
             <td rowspan=2 align="center">Intel(R) oneAPI Math Kernel Library</td>
             <td align="center">Dynamic, Static</td>
@@ -244,6 +254,12 @@ Supported domains: BLAS, LAPACK, RNG
             <td align="center">NETLIB LAPACK</td>
             <td align="center">Dynamic, Static</td>
             <td align="center">DPC++, LLVM*</td>
+        </tr>
+	    <tr >
+            <td align="center">Intel GPU</td>
+            <td align="center">SYCL-BLAS </td>
+            <td align="center">Dynamic, Static</td>
+            <td align="center">DPC++</td>
         </tr>
         <tr>
             <td rowspan=2 align="center">LAPACK</td>
@@ -421,6 +437,7 @@ Python | 3.6 or higher | No | *N/A* | *Pre-installed or Installed by user* | [PS
 [AMD rocRAND](https://github.com/ROCmSoftwarePlatform/rocRAND) | 5.1.0 | No | *N/A* | *Installed by user* |[AMD License](https://github.com/ROCmSoftwarePlatform/rocRAND/blob/develop/LICENSE.txt)
 [NETLIB LAPACK](https://www.netlib.org/) | 3.7.1 | Yes | conan-community | ~/.conan/data or $CONAN_USER_HOME/.conan/data | [BSD like license](http://www.netlib.org/lapack/LICENSE.txt)
 [Sphinx](https://www.sphinx-doc.org/en/master/) | 2.4.4 | Yes | pip | ~/.local/bin (or similar user local directory) | [BSD License](https://github.com/sphinx-doc/sphinx/blob/3.x/LICENSE)
+[SYCL-BLAS](https://github.com/codeplaysoftware/sycl-blas) | 0.1 | No | *N/A* | *Installed by user* | [Apache License v2.0](https://github.com/codeplaysoftware/sycl-blas/blob/master/LICENSE)
 
 *conan-center: https://api.bintray.com/conan/conan/conan-center*
 

--- a/cmake/FindSyclBLAS.cmake
+++ b/cmake/FindSyclBLAS.cmake
@@ -1,0 +1,60 @@
+#===============================================================================
+# Copyright Codeplay Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+#
+#
+# SPDX-License-Identifier: Apache-2.0
+#===============================================================================
+
+# Try to find the SyclBLAS library.
+#
+# If the library is found then the `SyclBLAS::SyclBLAS` target will be exported
+# with the required include directories.
+#
+# Sets the following variables:
+#   SyclBLAS_FOUND        - whether the system has SyclBLAS
+#   SyclBLAS_INCLUDE_DIRS - the SyclBLAS include directory
+
+find_path(SyclBLAS_INCLUDE_DIRS
+  NAMES sycl_blas.h
+  PATH_SUFFIXES include
+  HINTS ${SyclBLAS_DIR}
+  DOC "The SyclBLAS include directory"
+)
+
+find_library(SyclBLAS_LIBRARIES 
+  NAMES sycl_blas libsycl_blas
+  HINTS ${SyclBLAS_DIR}
+  PATH_SUFFIXES "lib"
+  DOC "The SyclBLAS shared library"
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(SyclBLAS
+  FOUND_VAR SyclBLAS_FOUND
+  REQUIRED_VARS SyclBLAS_INCLUDE_DIRS
+                SyclBLAS_LIBRARIES
+)
+
+mark_as_advanced(SyclBLAS_FOUND
+                 SyclBLAS_LIBRARIES
+)
+
+if(SyclBLAS_FOUND)
+  add_library(SyclBLAS::SyclBLAS UNKNOWN IMPORTED)
+  set_target_properties(SyclBLAS::SyclBLAS PROPERTIES
+    IMPORTED_LOCATION "${SyclBLAS_LIBRARIES}"
+    INTERFACE_INCLUDE_DIRECTORIES "${SyclBLAS_INCLUDE_DIRS}"
+  )
+endif()

--- a/docs/building_the_project.rst
+++ b/docs/building_the_project.rst
@@ -448,7 +448,8 @@ The installation directory of the SYCL-BLAS directory can be set with
 ``-DSyclBLAS_DIR=<path to SYCL-BLAS directory>``.
 
 SYCL-BLAS must be built using the same SYCL compiler as is used to compile
-OneMKL. Compile SYCL-BLAS with ``-DDOUBLE_SUPPORT=ON``.
+OneMKL. Compile SYCL-BLAS with ``-DBLAS_DATA_TYPES="half;float;double"`` 
+and ``-DBLAS_INDEX_TYPES="int64_t"``.
 
 
 Build Options

--- a/docs/building_the_project.rst
+++ b/docs/building_the_project.rst
@@ -427,6 +427,30 @@ A few often-used architectures are listed below:
      - | Radeon Instinct(TM) MI 25 Accelerator
        | Radeon(TM) RX Vega 64/56 Graphics
 
+Building for SYCL-BLAS
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   # Inside <path to onemkl>
+   mkdir build && cd build
+   cmake .. -DENABLE_SYCLBLAS_BACKEND=True                    \
+            -DENABLE_MKLCPU_BACKEND=False/True                     
+            -DENABLE_NETLIB_BACKEND=False/True                  
+            -DENABLE_MKLGPU_BACKEND=False                      
+            -DENABLE_ROCBLAS_BACKEND=True                     \
+            [-DREF_BLAS_ROOT=<reference_blas_install_prefix>]   # required only for testing
+   cmake --build .
+   ctest
+   cmake --install . --prefix <path_to_install_dir>
+
+The installation directory of the SYCL-BLAS directory can be set with
+``-DSyclBLAS_DIR=<path to SYCL-BLAS directory>``.
+
+SYCL-BLAS must be built using the same SYCL compiler as is used to compile
+OneMKL. Compile SYCL-BLAS with ``-DDOUBLE_SUPPORT=ON``.
+
+
 Build Options
 ^^^^^^^^^^^^^
 
@@ -488,6 +512,10 @@ CMake.
      - ENABLE_MKLCPU_THREAD_TBB
      - True, False
      - True      
+   * - *Not Supported*
+     - ENABLE_SYCLBLAS_BACKEND
+     - True, False
+     - False      
    * - build_functional_tests
      - BUILD_FUNCTIONAL_TESTS
      - True, False

--- a/include/oneapi/mkl/blas/detail/blas_ct_backends.hpp
+++ b/include/oneapi/mkl/blas/detail/blas_ct_backends.hpp
@@ -51,6 +51,9 @@ namespace column_major {
 #define BACKEND netlib
 #include "blas_ct_backends.hxx"
 #undef BACKEND
+#define BACKEND syclblas
+#include "blas_ct_backends.hxx"
+#undef BACKEND
 
 } //namespace column_major
 namespace row_major {
@@ -68,6 +71,9 @@ namespace row_major {
 #include "blas_ct_backends.hxx"
 #undef BACKEND
 #define BACKEND netlib
+#include "blas_ct_backends.hxx"
+#undef BACKEND
+#define BACKEND syclblas
 #include "blas_ct_backends.hxx"
 #undef BACKEND
 

--- a/include/oneapi/mkl/blas/detail/syclblas/blas_ct.hpp
+++ b/include/oneapi/mkl/blas/detail/syclblas/blas_ct.hpp
@@ -1,0 +1,57 @@
+/***************************************************************************
+*  Copyright (C) Codeplay Software Limited
+*  Licensed under the Apache License, Version 2.0 (the "License");
+*  you may not use this file except in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+*  For your convenience, a copy of the License has been included in this
+*  repository.
+*
+*  Unless required by applicable law or agreed to in writing, software
+*  distributed under the License is distributed on an "AS IS" BASIS,
+*  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+*  See the License for the specific language governing permissions and
+*  limitations under the License.
+*
+**************************************************************************/
+
+#ifndef _DETAIL_SYCLBLAS_BLAS_CT_HPP_
+#define _DETAIL_SYCLBLAS_BLAS_CT_HPP_
+
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+#include <complex>
+#include <cstdint>
+
+#include "oneapi/mkl/types.hpp"
+#include "oneapi/mkl/detail/backend_selector.hpp"
+#include "oneapi/mkl/blas/detail/syclblas/onemkl_blas_syclblas.hpp"
+#include "oneapi/mkl/blas/detail/blas_ct_backends.hpp"
+
+namespace oneapi {
+namespace mkl {
+namespace blas {
+namespace column_major {
+
+#define MAJOR column_major
+#include "blas_ct.hxx"
+#undef MAJOR
+
+} //namespace column_major
+namespace row_major {
+
+#define MAJOR row_major
+#include "blas_ct.hxx"
+#undef MAJOR
+
+} //namespace row_major
+} //namespace blas
+} //namespace mkl
+} //namespace oneapi
+
+#endif //_DETAIL_SYCLBLAS_BLAS_CT_HPP_

--- a/include/oneapi/mkl/blas/detail/syclblas/blas_ct.hxx
+++ b/include/oneapi/mkl/blas/detail/syclblas/blas_ct.hxx
@@ -1,0 +1,5211 @@
+/*******************************************************************************
+* Copyright Codeplay Software
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+// Buffer APIs
+
+void herk(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          std::int64_t n, std::int64_t k, float alpha, sycl::buffer<std::complex<float>, 1> &a,
+          std::int64_t lda, float beta, sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::herk(selector.get_queue(), upper_lower, trans, n, k, alpha,
+                                             a, lda, beta, c, ldc);
+    herk_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
+}
+
+void herk(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          std::int64_t n, std::int64_t k, double alpha, sycl::buffer<std::complex<double>, 1> &a,
+          std::int64_t lda, double beta, sycl::buffer<std::complex<double>, 1> &c,
+          std::int64_t ldc) {
+    herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::herk(selector.get_queue(), upper_lower, trans, n, k, alpha,
+                                             a, lda, beta, c, ldc);
+    herk_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
+}
+
+void scal(backend_selector<backend::syclblas> selector, std::int64_t n, float alpha,
+          sycl::buffer<float, 1> &x, std::int64_t incx) {
+    scal_precondition(selector.get_queue(), n, alpha, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx);
+    scal_postcondition(selector.get_queue(), n, alpha, x, incx);
+}
+
+void scal(backend_selector<backend::syclblas> selector, std::int64_t n, double alpha,
+          sycl::buffer<double, 1> &x, std::int64_t incx) {
+    scal_precondition(selector.get_queue(), n, alpha, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx);
+    scal_postcondition(selector.get_queue(), n, alpha, x, incx);
+}
+
+void scal(backend_selector<backend::syclblas> selector, std::int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    scal_precondition(selector.get_queue(), n, alpha, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx);
+    scal_postcondition(selector.get_queue(), n, alpha, x, incx);
+}
+
+void scal(backend_selector<backend::syclblas> selector, std::int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    scal_precondition(selector.get_queue(), n, alpha, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx);
+    scal_postcondition(selector.get_queue(), n, alpha, x, incx);
+}
+
+void scal(backend_selector<backend::syclblas> selector, std::int64_t n, float alpha,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    scal_precondition(selector.get_queue(), n, alpha, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx);
+    scal_postcondition(selector.get_queue(), n, alpha, x, incx);
+}
+
+void scal(backend_selector<backend::syclblas> selector, std::int64_t n, double alpha,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    scal_precondition(selector.get_queue(), n, alpha, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx);
+    scal_postcondition(selector.get_queue(), n, alpha, x, incx);
+}
+
+void trmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<float, 1> &a, std::int64_t lda,
+          sycl::buffer<float, 1> &x, std::int64_t incx) {
+    trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::trmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, lda, x, incx);
+    trmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+}
+
+void trmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<double, 1> &a, std::int64_t lda,
+          sycl::buffer<double, 1> &x, std::int64_t incx) {
+    trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::trmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, lda, x, incx);
+    trmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+}
+
+void trmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::trmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, lda, x, incx);
+    trmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+}
+
+void trmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<std::complex<double>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::trmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, lda, x, incx);
+    trmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+}
+
+void tpmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &x,
+          std::int64_t incx) {
+    tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, x, incx);
+    tpmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+}
+
+void tpmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &x,
+          std::int64_t incx) {
+    tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, x, incx);
+    tpmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+}
+
+void tpmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, x, incx);
+    tpmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+}
+
+void tpmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, x, incx);
+    tpmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+}
+
+void spr(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+         float alpha, sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &a) {
+    spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
+    oneapi::mkl::blas::syclblas::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha, x, incx,
+                                            a);
+    spr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
+}
+
+void spr(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+         double alpha, sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &a) {
+    spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
+    oneapi::mkl::blas::syclblas::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha, x, incx,
+                                            a);
+    spr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
+}
+
+void gemm_batch(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                sycl::buffer<float, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<float, 1> &b, std::int64_t ldb, std::int64_t stride_b, float beta,
+                sycl::buffer<float, 1> &c, std::int64_t ldc, std::int64_t stride_c,
+                std::int64_t batch_size) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                            b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(selector.get_queue(), transa, transb, m, n, k,
+                                                   alpha, a, lda, stride_a, b, ldb, stride_b, beta,
+                                                   c, ldc, stride_c, batch_size);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
+}
+
+void gemm_batch(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                std::int64_t m, std::int64_t n, std::int64_t k, double alpha,
+                sycl::buffer<double, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<double, 1> &b, std::int64_t ldb, std::int64_t stride_b, double beta,
+                sycl::buffer<double, 1> &c, std::int64_t ldc, std::int64_t stride_c,
+                std::int64_t batch_size) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                            b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(selector.get_queue(), transa, transb, m, n, k,
+                                                   alpha, a, lda, stride_a, b, ldb, stride_b, beta,
+                                                   c, ldc, stride_c, batch_size);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
+}
+
+void gemm_batch(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                            b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(selector.get_queue(), transa, transb, m, n, k,
+                                                   alpha, a, lda, stride_a, b, ldb, stride_b, beta,
+                                                   c, ldc, stride_c, batch_size);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
+}
+
+void gemm_batch(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c,
+                std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                            b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(selector.get_queue(), transa, transb, m, n, k,
+                                                   alpha, a, lda, stride_a, b, ldb, stride_b, beta,
+                                                   c, ldc, stride_c, batch_size);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
+}
+
+void gemm_batch(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                sycl::half beta, sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                            b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(selector.get_queue(), transa, transb, m, n, k,
+                                                   alpha, a, lda, stride_a, b, ldb, stride_b, beta,
+                                                   c, ldc, stride_c, batch_size);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size);
+}
+
+void syrk(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
+          float beta, sycl::buffer<float, 1> &c, std::int64_t ldc) {
+    syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::syrk(selector.get_queue(), upper_lower, trans, n, k, alpha,
+                                             a, lda, beta, c, ldc);
+    syrk_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
+}
+
+void syrk(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          std::int64_t n, std::int64_t k, double alpha, sycl::buffer<double, 1> &a,
+          std::int64_t lda, double beta, sycl::buffer<double, 1> &c, std::int64_t ldc) {
+    syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::syrk(selector.get_queue(), upper_lower, trans, n, k, alpha,
+                                             a, lda, beta, c, ldc);
+    syrk_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
+}
+
+void syrk(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          std::int64_t n, std::int64_t k, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::syrk(selector.get_queue(), upper_lower, trans, n, k, alpha,
+                                             a, lda, beta, c, ldc);
+    syrk_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
+}
+
+void syrk(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          std::int64_t n, std::int64_t k, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::syrk(selector.get_queue(), upper_lower, trans, n, k, alpha,
+                                             a, lda, beta, c, ldc);
+    syrk_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc);
+}
+
+void syrk_batch(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1> &a,
+                std::int64_t lda, std::int64_t stride_a, float beta, sycl::buffer<float, 1> &c,
+                std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
+                            beta, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::syrk_batch(selector.get_queue(), upper_lower, trans, n, k,
+                                                   alpha, a, lda, stride_a, beta, c, ldc, stride_c,
+                                                   batch_size);
+    syrk_batch_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda,
+                             stride_a, beta, c, ldc, stride_c, batch_size);
+}
+
+void syrk_batch(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                std::int64_t n, std::int64_t k, double alpha, sycl::buffer<double, 1> &a,
+                std::int64_t lda, std::int64_t stride_a, double beta, sycl::buffer<double, 1> &c,
+                std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
+                            beta, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::syrk_batch(selector.get_queue(), upper_lower, trans, n, k,
+                                                   alpha, a, lda, stride_a, beta, c, ldc, stride_c,
+                                                   batch_size);
+    syrk_batch_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda,
+                             stride_a, beta, c, ldc, stride_c, batch_size);
+}
+
+void syrk_batch(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size) {
+    syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
+                            beta, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::syrk_batch(selector.get_queue(), upper_lower, trans, n, k,
+                                                   alpha, a, lda, stride_a, beta, c, ldc, stride_c,
+                                                   batch_size);
+    syrk_batch_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda,
+                             stride_a, beta, c, ldc, stride_c, batch_size);
+}
+
+void syrk_batch(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c,
+                std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
+                            beta, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::syrk_batch(selector.get_queue(), upper_lower, trans, n, k,
+                                                   alpha, a, lda, stride_a, beta, c, ldc, stride_c,
+                                                   batch_size);
+    syrk_batch_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda,
+                             stride_a, beta, c, ldc, stride_c, batch_size);
+}
+
+void her2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda) {
+    her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha, x, incx,
+                                             y, incy, a, lda);
+    her2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void her2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda) {
+    her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::her2(selector.get_queue(), upper_lower, n, alpha, x, incx,
+                                             y, incy, a, lda);
+    her2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void hbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          std::int64_t k, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                      incy);
+    oneapi::mkl::blas::syclblas::MAJOR::hbmv(selector.get_queue(), upper_lower, n, k, alpha, a, lda,
+                                             x, incx, beta, y, incy);
+    hbmv_postcondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                       incy);
+}
+
+void hbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          std::int64_t k, std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                      incy);
+    oneapi::mkl::blas::syclblas::MAJOR::hbmv(selector.get_queue(), upper_lower, n, k, alpha, a, lda,
+                                             x, incx, beta, y, incy);
+    hbmv_postcondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                       incy);
+}
+
+void rot(backend_selector<backend::syclblas> selector, std::int64_t n,
+         sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+         sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy, float c, float s) {
+    rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s);
+    oneapi::mkl::blas::syclblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c, s);
+    rot_postcondition(selector.get_queue(), n, x, incx, y, incy, c, s);
+}
+
+void rot(backend_selector<backend::syclblas> selector, std::int64_t n,
+         sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+         sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy, double c, double s) {
+    rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s);
+    oneapi::mkl::blas::syclblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c, s);
+    rot_postcondition(selector.get_queue(), n, x, incx, y, incy, c, s);
+}
+
+void rot(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<float, 1> &x,
+         std::int64_t incx, sycl::buffer<float, 1> &y, std::int64_t incy, float c, float s) {
+    rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s);
+    oneapi::mkl::blas::syclblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c, s);
+    rot_postcondition(selector.get_queue(), n, x, incx, y, incy, c, s);
+}
+
+void rot(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<double, 1> &x,
+         std::int64_t incx, sycl::buffer<double, 1> &y, std::int64_t incy, double c, double s) {
+    rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s);
+    oneapi::mkl::blas::syclblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy, c, s);
+    rot_postcondition(selector.get_queue(), n, x, incx, y, incy, c, s);
+}
+
+void axpy(backend_selector<backend::syclblas> selector, std::int64_t n, float alpha,
+          sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &y,
+          std::int64_t incy) {
+    axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y, incy);
+    axpy_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy);
+}
+
+void axpy(backend_selector<backend::syclblas> selector, std::int64_t n, double alpha,
+          sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &y,
+          std::int64_t incy) {
+    axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y, incy);
+    axpy_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy);
+}
+
+void axpy(backend_selector<backend::syclblas> selector, std::int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y, incy);
+    axpy_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy);
+}
+
+void axpy(backend_selector<backend::syclblas> selector, std::int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y, incy);
+    axpy_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy);
+}
+
+void axpy_batch(backend_selector<backend::syclblas> selector, std::int64_t n, float alpha,
+                sycl::buffer<float, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<float, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                            batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x, incx, stridex,
+                                                   y, incy, stridey, batch_size);
+    axpy_batch_postcondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                             batch_size);
+}
+
+void axpy_batch(backend_selector<backend::syclblas> selector, std::int64_t n, double alpha,
+                sycl::buffer<double, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<double, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                            batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x, incx, stridex,
+                                                   y, incy, stridey, batch_size);
+    axpy_batch_postcondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                             batch_size);
+}
+
+void axpy_batch(backend_selector<backend::syclblas> selector, std::int64_t n,
+                std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x,
+                std::int64_t incx, std::int64_t stridex, sycl::buffer<std::complex<float>, 1> &y,
+                std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
+    axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                            batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x, incx, stridex,
+                                                   y, incy, stridey, batch_size);
+    axpy_batch_postcondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                             batch_size);
+}
+
+void axpy_batch(backend_selector<backend::syclblas> selector, std::int64_t n,
+                std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x,
+                std::int64_t incx, std::int64_t stridex, sycl::buffer<std::complex<double>, 1> &y,
+                std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
+    axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                            batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x, incx, stridex,
+                                                   y, incy, stridey, batch_size);
+    axpy_batch_postcondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                             batch_size);
+}
+
+void axpby(backend_selector<backend::syclblas> selector, std::int64_t n, float alpha,
+           sycl::buffer<float, 1> &x, std::int64_t incx, float beta, sycl::buffer<float, 1> &y,
+           std::int64_t incy) {
+    axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx, beta, y,
+                                              incy);
+    axpby_postcondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy);
+}
+
+void axpby(backend_selector<backend::syclblas> selector, std::int64_t n, double alpha,
+           sycl::buffer<double, 1> &x, std::int64_t incx, double beta, sycl::buffer<double, 1> &y,
+           std::int64_t incy) {
+    axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx, beta, y,
+                                              incy);
+    axpby_postcondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy);
+}
+
+void axpby(backend_selector<backend::syclblas> selector, std::int64_t n, std::complex<float> alpha,
+           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
+           sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx, beta, y,
+                                              incy);
+    axpby_postcondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy);
+}
+
+void axpby(backend_selector<backend::syclblas> selector, std::int64_t n, std::complex<double> alpha,
+           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx, beta, y,
+                                              incy);
+    axpby_postcondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy);
+}
+
+void sdsdot(backend_selector<backend::syclblas> selector, std::int64_t n, float sb,
+            sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &y,
+            std::int64_t incy, sycl::buffer<float, 1> &result) {
+    sdsdot_precondition(selector.get_queue(), n, sb, x, incx, y, incy, result);
+    oneapi::mkl::blas::syclblas::MAJOR::sdsdot(selector.get_queue(), n, sb, x, incx, y, incy,
+                                               result);
+    sdsdot_postcondition(selector.get_queue(), n, sb, x, incx, y, incy, result);
+}
+
+void gerc(backend_selector<backend::syclblas> selector, std::int64_t m, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda) {
+    gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx, y, incy, a,
+                                             lda);
+    gerc_postcondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void gerc(backend_selector<backend::syclblas> selector, std::int64_t m, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda) {
+    gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx, y, incy, a,
+                                             lda);
+    gerc_postcondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void syr2k(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+           std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
+           sycl::buffer<float, 1> &b, std::int64_t ldb, float beta, sycl::buffer<float, 1> &c,
+           std::int64_t ldc) {
+    syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::syr2k(selector.get_queue(), upper_lower, trans, n, k, alpha,
+                                              a, lda, b, ldb, beta, c, ldc);
+    syr2k_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                        c, ldc);
+}
+
+void syr2k(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+           std::int64_t n, std::int64_t k, double alpha, sycl::buffer<double, 1> &a,
+           std::int64_t lda, sycl::buffer<double, 1> &b, std::int64_t ldb, double beta,
+           sycl::buffer<double, 1> &c, std::int64_t ldc) {
+    syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::syr2k(selector.get_queue(), upper_lower, trans, n, k, alpha,
+                                              a, lda, b, ldb, beta, c, ldc);
+    syr2k_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                        c, ldc);
+}
+
+void syr2k(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+           std::int64_t n, std::int64_t k, std::complex<float> alpha,
+           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+           sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
+           sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::syr2k(selector.get_queue(), upper_lower, trans, n, k, alpha,
+                                              a, lda, b, ldb, beta, c, ldc);
+    syr2k_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                        c, ldc);
+}
+
+void syr2k(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+           std::int64_t n, std::int64_t k, std::complex<double> alpha,
+           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+           sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::syr2k(selector.get_queue(), upper_lower, trans, n, k, alpha,
+                                              a, lda, b, ldb, beta, c, ldc);
+    syr2k_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                        c, ldc);
+}
+
+void gemv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+          std::int64_t n, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
+          sycl::buffer<float, 1> &x, std::int64_t incx, float beta, sycl::buffer<float, 1> &y,
+          std::int64_t incy) {
+    gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a, lda, x,
+                                             incx, beta, y, incy);
+    gemv_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void gemv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+          std::int64_t n, double alpha, sycl::buffer<double, 1> &a, std::int64_t lda,
+          sycl::buffer<double, 1> &x, std::int64_t incx, double beta, sycl::buffer<double, 1> &y,
+          std::int64_t incy) {
+    gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a, lda, x,
+                                             incx, beta, y, incy);
+    gemv_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void gemv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+          std::int64_t n, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a, lda, x,
+                                             incx, beta, y, incy);
+    gemv_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void gemv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+          std::int64_t n, std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::gemv(selector.get_queue(), trans, m, n, alpha, a, lda, x,
+                                             incx, beta, y, incy);
+    gemv_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void gemv_batch(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                std::int64_t n, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
+                std::int64_t stridea, sycl::buffer<float, 1> &x, std::int64_t incx,
+                std::int64_t stridex, float beta, sycl::buffer<float, 1> &y, std::int64_t incy,
+                std::int64_t stridey, std::int64_t batch_size) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                            stridex, beta, y, incy, stridey, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::gemv_batch(selector.get_queue(), trans, m, n, alpha, a, lda,
+                                                   stridea, x, incx, stridex, beta, y, incy,
+                                                   stridey, batch_size);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                             stridex, beta, y, incy, stridey, batch_size);
+}
+
+void gemv_batch(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                std::int64_t n, double alpha, sycl::buffer<double, 1> &a, std::int64_t lda,
+                std::int64_t stridea, sycl::buffer<double, 1> &x, std::int64_t incx,
+                std::int64_t stridex, double beta, sycl::buffer<double, 1> &y, std::int64_t incy,
+                std::int64_t stridey, std::int64_t batch_size) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                            stridex, beta, y, incy, stridey, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::gemv_batch(selector.get_queue(), trans, m, n, alpha, a, lda,
+                                                   stridea, x, incx, stridex, beta, y, incy,
+                                                   stridey, batch_size);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                             stridex, beta, y, incy, stridey, batch_size);
+}
+
+void gemv_batch(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                std::int64_t n, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+                std::int64_t lda, std::int64_t stridea, sycl::buffer<std::complex<float>, 1> &x,
+                std::int64_t incx, std::int64_t stridex, std::complex<float> beta,
+                sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                            stridex, beta, y, incy, stridey, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::gemv_batch(selector.get_queue(), trans, m, n, alpha, a, lda,
+                                                   stridea, x, incx, stridex, beta, y, incy,
+                                                   stridey, batch_size);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                             stridex, beta, y, incy, stridey, batch_size);
+}
+
+void gemv_batch(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                std::int64_t n, std::complex<double> alpha,
+                sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda, std::int64_t stridea,
+                sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::int64_t stridex,
+                std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &y,
+                std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                            stridex, beta, y, incy, stridey, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::gemv_batch(selector.get_queue(), trans, m, n, alpha, a, lda,
+                                                   stridea, x, incx, stridex, beta, y, incy,
+                                                   stridey, batch_size);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                             stridex, beta, y, incy, stridey, batch_size);
+}
+
+void dgmm_batch(backend_selector<backend::syclblas> selector, side left_right, std::int64_t m,
+                std::int64_t n, sycl::buffer<float, 1> &a, std::int64_t lda, std::int64_t stridea,
+                sycl::buffer<float, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<float, 1> &c, std::int64_t ldc, std::int64_t stridec,
+                std::int64_t batch_size) {
+    dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                            stridex, c, ldc, stridec, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n, a, lda,
+                                                   stridea, x, incx, stridex, c, ldc, stridec,
+                                                   batch_size);
+    dgmm_batch_postcondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                             stridex, c, ldc, stridec, batch_size);
+}
+
+void dgmm_batch(backend_selector<backend::syclblas> selector, side left_right, std::int64_t m,
+                std::int64_t n, sycl::buffer<double, 1> &a, std::int64_t lda, std::int64_t stridea,
+                sycl::buffer<double, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<double, 1> &c, std::int64_t ldc, std::int64_t stridec,
+                std::int64_t batch_size) {
+    dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                            stridex, c, ldc, stridec, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n, a, lda,
+                                                   stridea, x, incx, stridex, c, ldc, stridec,
+                                                   batch_size);
+    dgmm_batch_postcondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                             stridex, c, ldc, stridec, batch_size);
+}
+
+void dgmm_batch(backend_selector<backend::syclblas> selector, side left_right, std::int64_t m,
+                std::int64_t n, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+                std::int64_t stridea, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+                std::int64_t stridex, sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc,
+                std::int64_t stridec, std::int64_t batch_size) {
+    dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                            stridex, c, ldc, stridec, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n, a, lda,
+                                                   stridea, x, incx, stridex, c, ldc, stridec,
+                                                   batch_size);
+    dgmm_batch_postcondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                             stridex, c, ldc, stridec, batch_size);
+}
+
+void dgmm_batch(backend_selector<backend::syclblas> selector, side left_right, std::int64_t m,
+                std::int64_t n, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+                std::int64_t stridea, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+                std::int64_t stridex, sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc,
+                std::int64_t stridec, std::int64_t batch_size) {
+    dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                            stridex, c, ldc, stridec, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::dgmm_batch(selector.get_queue(), left_right, m, n, a, lda,
+                                                   stridea, x, incx, stridex, c, ldc, stridec,
+                                                   batch_size);
+    dgmm_batch_postcondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                             stridex, c, ldc, stridec, batch_size);
+}
+
+void her(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+         float alpha, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+         sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda) {
+    her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::her(selector.get_queue(), upper_lower, n, alpha, x, incx, a,
+                                            lda);
+    her_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda);
+}
+
+void her(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+         double alpha, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+         sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda) {
+    her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::her(selector.get_queue(), upper_lower, n, alpha, x, incx, a,
+                                            lda);
+    her_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda);
+}
+
+void hpr(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+         float alpha, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+         sycl::buffer<std::complex<float>, 1> &a) {
+    hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
+    oneapi::mkl::blas::syclblas::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha, x, incx,
+                                            a);
+    hpr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
+}
+
+void hpr(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+         double alpha, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+         sycl::buffer<std::complex<double>, 1> &a) {
+    hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
+    oneapi::mkl::blas::syclblas::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha, x, incx,
+                                            a);
+    hpr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a);
+}
+
+void iamin(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<float, 1> &x,
+           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result) {
+    iamin_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+    iamin_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void iamin(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<double, 1> &x,
+           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result) {
+    iamin_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+    iamin_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void iamin(backend_selector<backend::syclblas> selector, std::int64_t n,
+           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+           sycl::buffer<std::int64_t, 1> &result) {
+    iamin_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+    iamin_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void iamin(backend_selector<backend::syclblas> selector, std::int64_t n,
+           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+           sycl::buffer<std::int64_t, 1> &result) {
+    iamin_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+    iamin_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void hpmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha, a, x,
+                                             incx, beta, y, incy);
+    hpmv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy);
+}
+
+void hpmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::hpmv(selector.get_queue(), upper_lower, n, alpha, a, x,
+                                             incx, beta, y, incy);
+    hpmv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy);
+}
+
+void spmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          float alpha, sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &x, std::int64_t incx,
+          float beta, sycl::buffer<float, 1> &y, std::int64_t incy) {
+    spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha, a, x,
+                                             incx, beta, y, incy);
+    spmv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy);
+}
+
+void spmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          double alpha, sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &x, std::int64_t incx,
+          double beta, sycl::buffer<double, 1> &y, std::int64_t incy) {
+    spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::spmv(selector.get_queue(), upper_lower, n, alpha, a, x,
+                                             incx, beta, y, incy);
+    spmv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy);
+}
+
+void gemm_bias(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+               offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+               sycl::buffer<int8_t, 1> &a, std::int64_t lda, int8_t ao, sycl::buffer<uint8_t, 1> &b,
+               std::int64_t ldb, uint8_t bo, float beta, sycl::buffer<int32_t, 1> &c,
+               std::int64_t ldc, sycl::buffer<int32_t, 1> &co) {
+    gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                           ao, b, ldb, bo, beta, c, ldc, co);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm_bias(selector.get_queue(), transa, transb, offsetc, m,
+                                                  n, k, alpha, a, lda, ao, b, ldb, bo, beta, c, ldc,
+                                                  co);
+    gemm_bias_postcondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                            ao, b, ldb, bo, beta, c, ldc, co);
+}
+
+void gemm_bias(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+               offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+               sycl::buffer<int8_t, 1> &a, std::int64_t lda, int8_t ao, sycl::buffer<int8_t, 1> &b,
+               std::int64_t ldb, int8_t bo, float beta, sycl::buffer<int32_t, 1> &c,
+               std::int64_t ldc, sycl::buffer<int32_t, 1> &co) {
+    gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                           ao, b, ldb, bo, beta, c, ldc, co);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm_bias(selector.get_queue(), transa, transb, offsetc, m,
+                                                  n, k, alpha, a, lda, ao, b, ldb, bo, beta, c, ldc,
+                                                  co);
+    gemm_bias_postcondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                            ao, b, ldb, bo, beta, c, ldc, co);
+}
+
+void gemm_bias(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+               offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+               sycl::buffer<uint8_t, 1> &a, std::int64_t lda, uint8_t ao,
+               sycl::buffer<int8_t, 1> &b, std::int64_t ldb, int8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, std::int64_t ldc, sycl::buffer<int32_t, 1> &co) {
+    gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                           ao, b, ldb, bo, beta, c, ldc, co);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm_bias(selector.get_queue(), transa, transb, offsetc, m,
+                                                  n, k, alpha, a, lda, ao, b, ldb, bo, beta, c, ldc,
+                                                  co);
+    gemm_bias_postcondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                            ao, b, ldb, bo, beta, c, ldc, co);
+}
+
+void gemm_bias(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+               offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+               sycl::buffer<uint8_t, 1> &a, std::int64_t lda, uint8_t ao,
+               sycl::buffer<uint8_t, 1> &b, std::int64_t ldb, uint8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, std::int64_t ldc, sycl::buffer<int32_t, 1> &co) {
+    gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                           ao, b, ldb, bo, beta, c, ldc, co);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm_bias(selector.get_queue(), transa, transb, offsetc, m,
+                                                  n, k, alpha, a, lda, ao, b, ldb, bo, beta, c, ldc,
+                                                  co);
+    gemm_bias_postcondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                            ao, b, ldb, bo, beta, c, ldc, co);
+}
+
+void swap(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<float, 1> &x,
+          std::int64_t incx, sycl::buffer<float, 1> &y, std::int64_t incy) {
+    swap_precondition(selector.get_queue(), n, x, incx, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy);
+    swap_postcondition(selector.get_queue(), n, x, incx, y, incy);
+}
+
+void swap(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<double, 1> &x,
+          std::int64_t incx, sycl::buffer<double, 1> &y, std::int64_t incy) {
+    swap_precondition(selector.get_queue(), n, x, incx, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy);
+    swap_postcondition(selector.get_queue(), n, x, incx, y, incy);
+}
+
+void swap(backend_selector<backend::syclblas> selector, std::int64_t n,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    swap_precondition(selector.get_queue(), n, x, incx, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy);
+    swap_postcondition(selector.get_queue(), n, x, incx, y, incy);
+}
+
+void swap(backend_selector<backend::syclblas> selector, std::int64_t n,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    swap_precondition(selector.get_queue(), n, x, incx, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy);
+    swap_postcondition(selector.get_queue(), n, x, incx, y, incy);
+}
+
+void geru(backend_selector<backend::syclblas> selector, std::int64_t m, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda) {
+    geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx, y, incy, a,
+                                             lda);
+    geru_postcondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void geru(backend_selector<backend::syclblas> selector, std::int64_t m, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda) {
+    geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx, y, incy, a,
+                                             lda);
+    geru_postcondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void nrm2(backend_selector<backend::syclblas> selector, std::int64_t n,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<float, 1> &result) {
+    nrm2_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result);
+    nrm2_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void nrm2(backend_selector<backend::syclblas> selector, std::int64_t n,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<double, 1> &result) {
+    nrm2_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result);
+    nrm2_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void nrm2(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<float, 1> &x,
+          std::int64_t incx, sycl::buffer<float, 1> &result) {
+    nrm2_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result);
+    nrm2_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void nrm2(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<double, 1> &x,
+          std::int64_t incx, sycl::buffer<double, 1> &result) {
+    nrm2_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result);
+    nrm2_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1> &a,
+          std::int64_t lda, sycl::buffer<float, 1> &b, std::int64_t ldb, float beta,
+          sycl::buffer<float, 1> &c, std::int64_t ldc) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha,
+                                             a, lda, b, ldb, beta, c, ldc);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+}
+
+void gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, double alpha, sycl::buffer<double, 1> &a,
+          std::int64_t lda, sycl::buffer<double, 1> &b, std::int64_t ldb, double beta,
+          sycl::buffer<double, 1> &c, std::int64_t ldc) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha,
+                                             a, lda, b, ldb, beta, c, ldc);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+}
+
+void gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha,
+                                             a, lda, b, ldb, beta, c, ldc);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+}
+
+void gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha,
+                                             a, lda, b, ldb, beta, c, ldc);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+}
+
+void gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+          sycl::buffer<sycl::half, 1> &a, std::int64_t lda, sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, sycl::half beta, sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha,
+                                             a, lda, b, ldb, beta, c, ldc);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+}
+
+void gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          sycl::buffer<sycl::half, 1> &a, std::int64_t lda, sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, float beta, sycl::buffer<float, 1> &c, std::int64_t ldc) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha,
+                                             a, lda, b, ldb, beta, c, ldc);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+}
+
+void gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, sycl::buffer<bfloat16, 1> &a,
+          std::int64_t lda, sycl::buffer<bfloat16, 1> &b, std::int64_t ldb, float beta,
+          sycl::buffer<float, 1> &c, std::int64_t ldc) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k, alpha,
+                                             a, lda, b, ldb, beta, c, ldc);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+}
+
+void syr2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          float alpha, sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &y,
+          std::int64_t incy, sycl::buffer<float, 1> &a, std::int64_t lda) {
+    syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha, x, incx,
+                                             y, incy, a, lda);
+    syr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void syr2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          double alpha, sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &y,
+          std::int64_t incy, sycl::buffer<double, 1> &a, std::int64_t lda) {
+    syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::syr2(selector.get_queue(), upper_lower, n, alpha, x, incx,
+                                             y, incy, a, lda);
+    syr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void ger(backend_selector<backend::syclblas> selector, std::int64_t m, std::int64_t n, float alpha,
+         sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &y, std::int64_t incy,
+         sycl::buffer<float, 1> &a, std::int64_t lda) {
+    ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx, y, incy, a,
+                                            lda);
+    ger_postcondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void ger(backend_selector<backend::syclblas> selector, std::int64_t m, std::int64_t n, double alpha,
+         sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &y,
+         std::int64_t incy, sycl::buffer<double, 1> &a, std::int64_t lda) {
+    ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx, y, incy, a,
+                                            lda);
+    ger_postcondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void trsm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
+          sycl::buffer<float, 1> &a, std::int64_t lda, sycl::buffer<float, 1> &b,
+          std::int64_t ldb) {
+    trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb);
+    oneapi::mkl::blas::syclblas::MAJOR::trsm(selector.get_queue(), left_right, upper_lower, trans,
+                                             unit_diag, m, n, alpha, a, lda, b, ldb);
+    trsm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb);
+}
+
+void trsm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
+          sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &b,
+          std::int64_t ldb) {
+    trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb);
+    oneapi::mkl::blas::syclblas::MAJOR::trsm(selector.get_queue(), left_right, upper_lower, trans,
+                                             unit_diag, m, n, alpha, a, lda, b, ldb);
+    trsm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb);
+}
+
+void trsm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb) {
+    trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb);
+    oneapi::mkl::blas::syclblas::MAJOR::trsm(selector.get_queue(), left_right, upper_lower, trans,
+                                             unit_diag, m, n, alpha, a, lda, b, ldb);
+    trsm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb);
+}
+
+void trsm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb) {
+    trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb);
+    oneapi::mkl::blas::syclblas::MAJOR::trsm(selector.get_queue(), left_right, upper_lower, trans,
+                                             unit_diag, m, n, alpha, a, lda, b, ldb);
+    trsm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb);
+}
+
+void dotu(backend_selector<backend::syclblas> selector, std::int64_t n,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &result) {
+    dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result);
+    oneapi::mkl::blas::syclblas::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy, result);
+    dotu_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
+}
+
+void dotu(backend_selector<backend::syclblas> selector, std::int64_t n,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &result) {
+    dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result);
+    oneapi::mkl::blas::syclblas::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy, result);
+    dotu_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
+}
+
+void hemm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          std::int64_t m, std::int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::hemm(selector.get_queue(), left_right, upper_lower, m, n,
+                                             alpha, a, lda, b, ldb, beta, c, ldc);
+    hemm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc);
+}
+
+void hemm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          std::int64_t m, std::int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::hemm(selector.get_queue(), left_right, upper_lower, m, n,
+                                             alpha, a, lda, b, ldb, beta, c, ldc);
+    hemm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc);
+}
+
+void hpr2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a) {
+    hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
+    oneapi::mkl::blas::syclblas::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha, x, incx,
+                                             y, incy, a);
+    hpr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
+}
+
+void hpr2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a) {
+    hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
+    oneapi::mkl::blas::syclblas::MAJOR::hpr2(selector.get_queue(), upper_lower, n, alpha, x, incx,
+                                             y, incy, a);
+    hpr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
+}
+
+void gbmv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+          std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha, sycl::buffer<float, 1> &a,
+          std::int64_t lda, sycl::buffer<float, 1> &x, std::int64_t incx, float beta,
+          sycl::buffer<float, 1> &y, std::int64_t incy) {
+    gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                      incy);
+    oneapi::mkl::blas::syclblas::MAJOR::gbmv(selector.get_queue(), trans, m, n, kl, ku, alpha, a,
+                                             lda, x, incx, beta, y, incy);
+    gbmv_postcondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                       incy);
+}
+
+void gbmv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+          std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha,
+          sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &x,
+          std::int64_t incx, double beta, sycl::buffer<double, 1> &y, std::int64_t incy) {
+    gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                      incy);
+    oneapi::mkl::blas::syclblas::MAJOR::gbmv(selector.get_queue(), trans, m, n, kl, ku, alpha, a,
+                                             lda, x, incx, beta, y, incy);
+    gbmv_postcondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                       incy);
+}
+
+void gbmv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+          std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                      incy);
+    oneapi::mkl::blas::syclblas::MAJOR::gbmv(selector.get_queue(), trans, m, n, kl, ku, alpha, a,
+                                             lda, x, incx, beta, y, incy);
+    gbmv_postcondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                       incy);
+}
+
+void gbmv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+          std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                      incy);
+    oneapi::mkl::blas::syclblas::MAJOR::gbmv(selector.get_queue(), trans, m, n, kl, ku, alpha, a,
+                                             lda, x, incx, beta, y, incy);
+    gbmv_postcondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                       incy);
+}
+
+void tbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<float, 1> &a,
+          std::int64_t lda, sycl::buffer<float, 1> &x, std::int64_t incx) {
+    tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tbmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             k, a, lda, x, incx);
+    tbmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+}
+
+void tbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<double, 1> &a,
+          std::int64_t lda, sycl::buffer<double, 1> &x, std::int64_t incx) {
+    tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tbmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             k, a, lda, x, incx);
+    tbmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+}
+
+void tbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<std::complex<float>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tbmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             k, a, lda, x, incx);
+    tbmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+}
+
+void tbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<std::complex<double>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tbmv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             k, a, lda, x, incx);
+    tbmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+}
+
+void symm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          std::int64_t m, std::int64_t n, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
+          sycl::buffer<float, 1> &b, std::int64_t ldb, float beta, sycl::buffer<float, 1> &c,
+          std::int64_t ldc) {
+    symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::symm(selector.get_queue(), left_right, upper_lower, m, n,
+                                             alpha, a, lda, b, ldb, beta, c, ldc);
+    symm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc);
+}
+
+void symm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          std::int64_t m, std::int64_t n, double alpha, sycl::buffer<double, 1> &a,
+          std::int64_t lda, sycl::buffer<double, 1> &b, std::int64_t ldb, double beta,
+          sycl::buffer<double, 1> &c, std::int64_t ldc) {
+    symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::symm(selector.get_queue(), left_right, upper_lower, m, n,
+                                             alpha, a, lda, b, ldb, beta, c, ldc);
+    symm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc);
+}
+
+void symm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          std::int64_t m, std::int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::symm(selector.get_queue(), left_right, upper_lower, m, n,
+                                             alpha, a, lda, b, ldb, beta, c, ldc);
+    symm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc);
+}
+
+void symm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          std::int64_t m, std::int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::symm(selector.get_queue(), left_right, upper_lower, m, n,
+                                             alpha, a, lda, b, ldb, beta, c, ldc);
+    symm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc);
+}
+
+void dotc(backend_selector<backend::syclblas> selector, std::int64_t n,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &result) {
+    dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result);
+    oneapi::mkl::blas::syclblas::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy, result);
+    dotc_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
+}
+
+void dotc(backend_selector<backend::syclblas> selector, std::int64_t n,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &result) {
+    dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result);
+    oneapi::mkl::blas::syclblas::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy, result);
+    dotc_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
+}
+
+void syr(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+         float alpha, sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &a,
+         std::int64_t lda) {
+    syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha, x, incx, a,
+                                            lda);
+    syr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda);
+}
+
+void syr(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+         double alpha, sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &a,
+         std::int64_t lda) {
+    syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda);
+    oneapi::mkl::blas::syclblas::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha, x, incx, a,
+                                            lda);
+    syr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda);
+}
+
+void trmm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
+          sycl::buffer<float, 1> &a, std::int64_t lda, sycl::buffer<float, 1> &b,
+          std::int64_t ldb) {
+    trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb);
+    oneapi::mkl::blas::syclblas::MAJOR::trmm(selector.get_queue(), left_right, upper_lower, trans,
+                                             unit_diag, m, n, alpha, a, lda, b, ldb);
+    trmm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb);
+}
+
+void trmm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
+          sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &b,
+          std::int64_t ldb) {
+    trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb);
+    oneapi::mkl::blas::syclblas::MAJOR::trmm(selector.get_queue(), left_right, upper_lower, trans,
+                                             unit_diag, m, n, alpha, a, lda, b, ldb);
+    trmm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb);
+}
+
+void trmm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb) {
+    trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb);
+    oneapi::mkl::blas::syclblas::MAJOR::trmm(selector.get_queue(), left_right, upper_lower, trans,
+                                             unit_diag, m, n, alpha, a, lda, b, ldb);
+    trmm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb);
+}
+
+void trmm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+          transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb) {
+    trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb);
+    oneapi::mkl::blas::syclblas::MAJOR::trmm(selector.get_queue(), left_right, upper_lower, trans,
+                                             unit_diag, m, n, alpha, a, lda, b, ldb);
+    trmm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb);
+}
+
+void rotmg(backend_selector<backend::syclblas> selector, sycl::buffer<float, 1> &d1,
+           sycl::buffer<float, 1> &d2, sycl::buffer<float, 1> &x1, float y1,
+           sycl::buffer<float, 1> &param) {
+    rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param);
+    oneapi::mkl::blas::syclblas::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param);
+    rotmg_postcondition(selector.get_queue(), d1, d2, x1, y1, param);
+}
+
+void rotmg(backend_selector<backend::syclblas> selector, sycl::buffer<double, 1> &d1,
+           sycl::buffer<double, 1> &d2, sycl::buffer<double, 1> &x1, double y1,
+           sycl::buffer<double, 1> &param) {
+    rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param);
+    oneapi::mkl::blas::syclblas::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1, param);
+    rotmg_postcondition(selector.get_queue(), d1, d2, x1, y1, param);
+}
+
+void tpsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &x,
+          std::int64_t incx) {
+    tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, x, incx);
+    tpsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+}
+
+void tpsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &x,
+          std::int64_t incx) {
+    tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, x, incx);
+    tpsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+}
+
+void tpsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, x, incx);
+    tpsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+}
+
+void tpsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, x, incx);
+    tpsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx);
+}
+
+void trsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<float, 1> &a, std::int64_t lda,
+          sycl::buffer<float, 1> &x, std::int64_t incx) {
+    trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::trsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, lda, x, incx);
+    trsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+}
+
+void trsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<double, 1> &a, std::int64_t lda,
+          sycl::buffer<double, 1> &x, std::int64_t incx) {
+    trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::trsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, lda, x, incx);
+    trsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+}
+
+void trsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::trsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, lda, x, incx);
+    trsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+}
+
+void trsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, sycl::buffer<std::complex<double>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::trsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             a, lda, x, incx);
+    trsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx);
+}
+
+void copy(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<float, 1> &x,
+          std::int64_t incx, sycl::buffer<float, 1> &y, std::int64_t incy) {
+    copy_precondition(selector.get_queue(), n, x, incx, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy);
+    copy_postcondition(selector.get_queue(), n, x, incx, y, incy);
+}
+
+void copy(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<double, 1> &x,
+          std::int64_t incx, sycl::buffer<double, 1> &y, std::int64_t incy) {
+    copy_precondition(selector.get_queue(), n, x, incx, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy);
+    copy_postcondition(selector.get_queue(), n, x, incx, y, incy);
+}
+
+void copy(backend_selector<backend::syclblas> selector, std::int64_t n,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    copy_precondition(selector.get_queue(), n, x, incx, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy);
+    copy_postcondition(selector.get_queue(), n, x, incx, y, incy);
+}
+
+void copy(backend_selector<backend::syclblas> selector, std::int64_t n,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    copy_precondition(selector.get_queue(), n, x, incx, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy);
+    copy_postcondition(selector.get_queue(), n, x, incx, y, incy);
+}
+
+void copy_batch(backend_selector<backend::syclblas> selector, std::int64_t n,
+                sycl::buffer<float, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<float, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                            batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::copy_batch(selector.get_queue(), n, x, incx, stridex, y,
+                                                   incy, stridey, batch_size);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                             batch_size);
+}
+
+void copy_batch(backend_selector<backend::syclblas> selector, std::int64_t n,
+                sycl::buffer<double, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<double, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                            batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::copy_batch(selector.get_queue(), n, x, incx, stridex, y,
+                                                   incy, stridey, batch_size);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                             batch_size);
+}
+
+void copy_batch(backend_selector<backend::syclblas> selector, std::int64_t n,
+                sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                            batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::copy_batch(selector.get_queue(), n, x, incx, stridex, y,
+                                                   incy, stridey, batch_size);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                             batch_size);
+}
+
+void copy_batch(backend_selector<backend::syclblas> selector, std::int64_t n,
+                sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                            batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::copy_batch(selector.get_queue(), n, x, incx, stridex, y,
+                                                   incy, stridey, batch_size);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                             batch_size);
+}
+
+void hemv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::hemv(selector.get_queue(), upper_lower, n, alpha, a, lda, x,
+                                             incx, beta, y, incy);
+    hemv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void hemv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::hemv(selector.get_queue(), upper_lower, n, alpha, a, lda, x,
+                                             incx, beta, y, incy);
+    hemv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void gemmt(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose transa,
+           transpose transb, std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1> &a,
+           std::int64_t lda, sycl::buffer<float, 1> &b, std::int64_t ldb, float beta,
+           sycl::buffer<float, 1> &c, std::int64_t ldc) {
+    gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                       ldb, beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa, transb, n,
+                                              k, alpha, a, lda, b, ldb, beta, c, ldc);
+    gemmt_postcondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                        ldb, beta, c, ldc);
+}
+
+void gemmt(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose transa,
+           transpose transb, std::int64_t n, std::int64_t k, double alpha,
+           sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &b,
+           std::int64_t ldb, double beta, sycl::buffer<double, 1> &c, std::int64_t ldc) {
+    gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                       ldb, beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa, transb, n,
+                                              k, alpha, a, lda, b, ldb, beta, c, ldc);
+    gemmt_postcondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                        ldb, beta, c, ldc);
+}
+
+void gemmt(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose transa,
+           transpose transb, std::int64_t n, std::int64_t k, std::complex<float> alpha,
+           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+           sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
+           sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                       ldb, beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa, transb, n,
+                                              k, alpha, a, lda, b, ldb, beta, c, ldc);
+    gemmt_postcondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                        ldb, beta, c, ldc);
+}
+
+void gemmt(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose transa,
+           transpose transb, std::int64_t n, std::int64_t k, std::complex<double> alpha,
+           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+           sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                       ldb, beta, c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa, transb, n,
+                                              k, alpha, a, lda, b, ldb, beta, c, ldc);
+    gemmt_postcondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                        ldb, beta, c, ldc);
+}
+
+void asum(backend_selector<backend::syclblas> selector, std::int64_t n,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<float, 1> &result) {
+    asum_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::asum(selector.get_queue(), n, x, incx, result);
+    asum_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void asum(backend_selector<backend::syclblas> selector, std::int64_t n,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<double, 1> &result) {
+    asum_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::asum(selector.get_queue(), n, x, incx, result);
+    asum_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void asum(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<float, 1> &x,
+          std::int64_t incx, sycl::buffer<float, 1> &result) {
+    asum_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::asum(selector.get_queue(), n, x, incx, result);
+    asum_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void asum(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<double, 1> &x,
+          std::int64_t incx, sycl::buffer<double, 1> &result) {
+    asum_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::asum(selector.get_queue(), n, x, incx, result);
+    asum_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void sbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          std::int64_t k, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
+          sycl::buffer<float, 1> &x, std::int64_t incx, float beta, sycl::buffer<float, 1> &y,
+          std::int64_t incy) {
+    sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                      incy);
+    oneapi::mkl::blas::syclblas::MAJOR::sbmv(selector.get_queue(), upper_lower, n, k, alpha, a, lda,
+                                             x, incx, beta, y, incy);
+    sbmv_postcondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                       incy);
+}
+
+void sbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          std::int64_t k, double alpha, sycl::buffer<double, 1> &a, std::int64_t lda,
+          sycl::buffer<double, 1> &x, std::int64_t incx, double beta, sycl::buffer<double, 1> &y,
+          std::int64_t incy) {
+    sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                      incy);
+    oneapi::mkl::blas::syclblas::MAJOR::sbmv(selector.get_queue(), upper_lower, n, k, alpha, a, lda,
+                                             x, incx, beta, y, incy);
+    sbmv_postcondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                       incy);
+}
+
+void tbsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<float, 1> &a,
+          std::int64_t lda, sycl::buffer<float, 1> &x, std::int64_t incx) {
+    tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tbsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             k, a, lda, x, incx);
+    tbsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+}
+
+void tbsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<double, 1> &a,
+          std::int64_t lda, sycl::buffer<double, 1> &x, std::int64_t incx) {
+    tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tbsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             k, a, lda, x, incx);
+    tbsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+}
+
+void tbsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<std::complex<float>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tbsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             k, a, lda, x, incx);
+    tbsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+}
+
+void tbsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+          diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<std::complex<double>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+    oneapi::mkl::blas::syclblas::MAJOR::tbsv(selector.get_queue(), upper_lower, trans, unit_diag, n,
+                                             k, a, lda, x, incx);
+    tbsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx);
+}
+
+void spr2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          float alpha, sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &y,
+          std::int64_t incy, sycl::buffer<float, 1> &a) {
+    spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
+    oneapi::mkl::blas::syclblas::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha, x, incx,
+                                             y, incy, a);
+    spr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
+}
+
+void spr2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          double alpha, sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &y,
+          std::int64_t incy, sycl::buffer<double, 1> &a) {
+    spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
+    oneapi::mkl::blas::syclblas::MAJOR::spr2(selector.get_queue(), upper_lower, n, alpha, x, incx,
+                                             y, incy, a);
+    spr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a);
+}
+
+void iamax(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<float, 1> &x,
+           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result) {
+    iamax_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+    iamax_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void iamax(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<double, 1> &x,
+           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result) {
+    iamax_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+    iamax_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void iamax(backend_selector<backend::syclblas> selector, std::int64_t n,
+           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+           sycl::buffer<std::int64_t, 1> &result) {
+    iamax_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+    iamax_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void iamax(backend_selector<backend::syclblas> selector, std::int64_t n,
+           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+           sycl::buffer<std::int64_t, 1> &result) {
+    iamax_precondition(selector.get_queue(), n, x, incx, result);
+    oneapi::mkl::blas::syclblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+    iamax_postcondition(selector.get_queue(), n, x, incx, result);
+}
+
+void rotm(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<float, 1> &x,
+          std::int64_t incx, sycl::buffer<float, 1> &y, std::int64_t incy,
+          sycl::buffer<float, 1> &param) {
+    rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param);
+    oneapi::mkl::blas::syclblas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy, param);
+    rotm_postcondition(selector.get_queue(), n, x, incx, y, incy, param);
+}
+
+void rotm(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<double, 1> &x,
+          std::int64_t incx, sycl::buffer<double, 1> &y, std::int64_t incy,
+          sycl::buffer<double, 1> &param) {
+    rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param);
+    oneapi::mkl::blas::syclblas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy, param);
+    rotm_postcondition(selector.get_queue(), n, x, incx, y, incy, param);
+}
+
+void dot(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<float, 1> &x,
+         std::int64_t incx, sycl::buffer<float, 1> &y, std::int64_t incy,
+         sycl::buffer<float, 1> &result) {
+    dot_precondition(selector.get_queue(), n, x, incx, y, incy, result);
+    oneapi::mkl::blas::syclblas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy, result);
+    dot_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
+}
+
+void dot(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<double, 1> &x,
+         std::int64_t incx, sycl::buffer<double, 1> &y, std::int64_t incy,
+         sycl::buffer<double, 1> &result) {
+    dot_precondition(selector.get_queue(), n, x, incx, y, incy, result);
+    oneapi::mkl::blas::syclblas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy, result);
+    dot_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
+}
+
+void dot(backend_selector<backend::syclblas> selector, std::int64_t n, sycl::buffer<float, 1> &x,
+         std::int64_t incx, sycl::buffer<float, 1> &y, std::int64_t incy,
+         sycl::buffer<double, 1> &result) {
+    dot_precondition(selector.get_queue(), n, x, incx, y, incy, result);
+    oneapi::mkl::blas::syclblas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy, result);
+    dot_postcondition(selector.get_queue(), n, x, incx, y, incy, result);
+}
+
+void trsm_batch(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
+                sycl::buffer<float, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<float, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                std::int64_t batch_size) {
+    trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                            alpha, a, lda, stride_a, b, ldb, stride_b, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::trsm_batch(selector.get_queue(), left_right, upper_lower,
+                                                   trans, unit_diag, m, n, alpha, a, lda, stride_a,
+                                                   b, ldb, stride_b, batch_size);
+    trsm_batch_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size);
+}
+
+void trsm_batch(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
+                sycl::buffer<double, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<double, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                std::int64_t batch_size) {
+    trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                            alpha, a, lda, stride_a, b, ldb, stride_b, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::trsm_batch(selector.get_queue(), left_right, upper_lower,
+                                                   trans, unit_diag, m, n, alpha, a, lda, stride_a,
+                                                   b, ldb, stride_b, batch_size);
+    trsm_batch_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size);
+}
+
+void trsm_batch(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+                std::int64_t lda, std::int64_t stride_a, sycl::buffer<std::complex<float>, 1> &b,
+                std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size) {
+    trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                            alpha, a, lda, stride_a, b, ldb, stride_b, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::trsm_batch(selector.get_queue(), left_right, upper_lower,
+                                                   trans, unit_diag, m, n, alpha, a, lda, stride_a,
+                                                   b, ldb, stride_b, batch_size);
+    trsm_batch_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size);
+}
+
+void trsm_batch(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+                std::int64_t lda, std::int64_t stride_a, sycl::buffer<std::complex<double>, 1> &b,
+                std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size) {
+    trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                            alpha, a, lda, stride_a, b, ldb, stride_b, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::trsm_batch(selector.get_queue(), left_right, upper_lower,
+                                                   trans, unit_diag, m, n, alpha, a, lda, stride_a,
+                                                   b, ldb, stride_b, batch_size);
+    trsm_batch_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size);
+}
+
+void her2k(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+           std::int64_t n, std::int64_t k, std::complex<float> alpha,
+           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+           sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, float beta,
+           sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::her2k(selector.get_queue(), upper_lower, trans, n, k, alpha,
+                                              a, lda, b, ldb, beta, c, ldc);
+    her2k_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                        c, ldc);
+}
+
+void her2k(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+           std::int64_t n, std::int64_t k, std::complex<double> alpha,
+           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+           sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, double beta,
+           sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc);
+    oneapi::mkl::blas::syclblas::MAJOR::her2k(selector.get_queue(), upper_lower, trans, n, k, alpha,
+                                              a, lda, b, ldb, beta, c, ldc);
+    her2k_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                        c, ldc);
+}
+
+void rotg(backend_selector<backend::syclblas> selector, sycl::buffer<float, 1> &a,
+          sycl::buffer<float, 1> &b, sycl::buffer<float, 1> &c, sycl::buffer<float, 1> &s) {
+    rotg_precondition(selector.get_queue(), a, b, c, s);
+    oneapi::mkl::blas::syclblas::MAJOR::rotg(selector.get_queue(), a, b, c, s);
+    rotg_postcondition(selector.get_queue(), a, b, c, s);
+}
+
+void rotg(backend_selector<backend::syclblas> selector, sycl::buffer<double, 1> &a,
+          sycl::buffer<double, 1> &b, sycl::buffer<double, 1> &c, sycl::buffer<double, 1> &s) {
+    rotg_precondition(selector.get_queue(), a, b, c, s);
+    oneapi::mkl::blas::syclblas::MAJOR::rotg(selector.get_queue(), a, b, c, s);
+    rotg_postcondition(selector.get_queue(), a, b, c, s);
+}
+
+void rotg(backend_selector<backend::syclblas> selector, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &b, sycl::buffer<float, 1> &c,
+          sycl::buffer<std::complex<float>, 1> &s) {
+    rotg_precondition(selector.get_queue(), a, b, c, s);
+    oneapi::mkl::blas::syclblas::MAJOR::rotg(selector.get_queue(), a, b, c, s);
+    rotg_postcondition(selector.get_queue(), a, b, c, s);
+}
+
+void rotg(backend_selector<backend::syclblas> selector, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &b, sycl::buffer<double, 1> &c,
+          sycl::buffer<std::complex<double>, 1> &s) {
+    rotg_precondition(selector.get_queue(), a, b, c, s);
+    oneapi::mkl::blas::syclblas::MAJOR::rotg(selector.get_queue(), a, b, c, s);
+    rotg_postcondition(selector.get_queue(), a, b, c, s);
+}
+
+void symv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          float alpha, sycl::buffer<float, 1> &a, std::int64_t lda, sycl::buffer<float, 1> &x,
+          std::int64_t incx, float beta, sycl::buffer<float, 1> &y, std::int64_t incy) {
+    symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::symv(selector.get_queue(), upper_lower, n, alpha, a, lda, x,
+                                             incx, beta, y, incy);
+    symv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void symv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+          double alpha, sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &x,
+          std::int64_t incx, double beta, sycl::buffer<double, 1> &y, std::int64_t incy) {
+    symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
+    oneapi::mkl::blas::syclblas::MAJOR::symv(selector.get_queue(), upper_lower, n, alpha, a, lda, x,
+                                             incx, beta, y, incy);
+    symv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void omatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                    std::int64_t n, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
+                    std::int64_t stride_a, sycl::buffer<float, 1> &b, std::int64_t ldb,
+                    std::int64_t stride_b, std::int64_t batch_size) {
+    omatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                stride_b, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::omatcopy_batch(selector.get_queue(), trans, m, n, alpha, a,
+                                                       lda, stride_a, b, ldb, stride_b, batch_size);
+    omatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                 stride_b, batch_size);
+}
+
+void omatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                    std::int64_t n, double alpha, sycl::buffer<double, 1> &a, std::int64_t lda,
+                    std::int64_t stride_a, sycl::buffer<double, 1> &b, std::int64_t ldb,
+                    std::int64_t stride_b, std::int64_t batch_size) {
+    omatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                stride_b, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::omatcopy_batch(selector.get_queue(), trans, m, n, alpha, a,
+                                                       lda, stride_a, b, ldb, stride_b, batch_size);
+    omatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                 stride_b, batch_size);
+}
+
+void omatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                    std::int64_t n, std::complex<float> alpha,
+                    sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+                    std::int64_t stride_a, sycl::buffer<std::complex<float>, 1> &b,
+                    std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size) {
+    omatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                stride_b, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::omatcopy_batch(selector.get_queue(), trans, m, n, alpha, a,
+                                                       lda, stride_a, b, ldb, stride_b, batch_size);
+    omatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                 stride_b, batch_size);
+}
+
+void omatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                    std::int64_t n, std::complex<double> alpha,
+                    sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+                    std::int64_t stride_a, sycl::buffer<std::complex<double>, 1> &b,
+                    std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size) {
+    omatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                stride_b, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::omatcopy_batch(selector.get_queue(), trans, m, n, alpha, a,
+                                                       lda, stride_a, b, ldb, stride_b, batch_size);
+    omatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                 stride_b, batch_size);
+}
+
+void imatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                    std::int64_t n, float alpha, sycl::buffer<float, 1> &ab, std::int64_t lda,
+                    std::int64_t ldb, std::int64_t stride, std::int64_t batch_size) {
+    imatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::imatcopy_batch(selector.get_queue(), trans, m, n, alpha, ab,
+                                                       lda, ldb, stride, batch_size);
+    imatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                 batch_size);
+}
+
+void imatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                    std::int64_t n, double alpha, sycl::buffer<double, 1> &ab, std::int64_t lda,
+                    std::int64_t ldb, std::int64_t stride, std::int64_t batch_size) {
+    imatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::imatcopy_batch(selector.get_queue(), trans, m, n, alpha, ab,
+                                                       lda, ldb, stride, batch_size);
+    imatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                 batch_size);
+}
+
+void imatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                    std::int64_t n, std::complex<float> alpha,
+                    sycl::buffer<std::complex<float>, 1> &ab, std::int64_t lda, std::int64_t ldb,
+                    std::int64_t stride, std::int64_t batch_size) {
+    imatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::imatcopy_batch(selector.get_queue(), trans, m, n, alpha, ab,
+                                                       lda, ldb, stride, batch_size);
+    imatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                 batch_size);
+}
+
+void imatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                    std::int64_t n, std::complex<double> alpha,
+                    sycl::buffer<std::complex<double>, 1> &ab, std::int64_t lda, std::int64_t ldb,
+                    std::int64_t stride, std::int64_t batch_size) {
+    imatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::imatcopy_batch(selector.get_queue(), trans, m, n, alpha, ab,
+                                                       lda, ldb, stride, batch_size);
+    imatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                 batch_size);
+}
+
+void omatadd_batch(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                   std::int64_t m, std::int64_t n, float alpha, sycl::buffer<float, 1> &a,
+                   std::int64_t lda, std::int64_t stride_a, float beta, sycl::buffer<float, 1> &b,
+                   std::int64_t ldb, std::int64_t stride_b, sycl::buffer<float, 1> &c,
+                   std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    omatadd_batch_precondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                               beta, b, ldb, stride_b, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::omatadd_batch(selector.get_queue(), transa, transb, m, n,
+                                                      alpha, a, lda, stride_a, beta, b, ldb,
+                                                      stride_b, c, ldc, stride_c, batch_size);
+    omatadd_batch_postcondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                                beta, b, ldb, stride_b, c, ldc, stride_c, batch_size);
+}
+
+void omatadd_batch(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                   std::int64_t m, std::int64_t n, double alpha, sycl::buffer<double, 1> &a,
+                   std::int64_t lda, std::int64_t stride_a, double beta, sycl::buffer<double, 1> &b,
+                   std::int64_t ldb, std::int64_t stride_b, sycl::buffer<double, 1> &c,
+                   std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    omatadd_batch_precondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                               beta, b, ldb, stride_b, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::omatadd_batch(selector.get_queue(), transa, transb, m, n,
+                                                      alpha, a, lda, stride_a, beta, b, ldb,
+                                                      stride_b, c, ldc, stride_c, batch_size);
+    omatadd_batch_postcondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                                beta, b, ldb, stride_b, c, ldc, stride_c, batch_size);
+}
+
+void omatadd_batch(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                   std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                   sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                   std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &b,
+                   std::int64_t ldb, std::int64_t stride_b, sycl::buffer<std::complex<float>, 1> &c,
+                   std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    omatadd_batch_precondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                               beta, b, ldb, stride_b, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::omatadd_batch(selector.get_queue(), transa, transb, m, n,
+                                                      alpha, a, lda, stride_a, beta, b, ldb,
+                                                      stride_b, c, ldc, stride_c, batch_size);
+    omatadd_batch_postcondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                                beta, b, ldb, stride_b, c, ldc, stride_c, batch_size);
+}
+
+void omatadd_batch(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                   std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                   sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+                   std::int64_t stride_a, std::complex<double> beta,
+                   sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb,
+                   std::int64_t stride_b, sycl::buffer<std::complex<double>, 1> &c,
+                   std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    omatadd_batch_precondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                               beta, b, ldb, stride_b, c, ldc, stride_c, batch_size);
+    oneapi::mkl::blas::syclblas::MAJOR::omatadd_batch(selector.get_queue(), transa, transb, m, n,
+                                                      alpha, a, lda, stride_a, beta, b, ldb,
+                                                      stride_b, c, ldc, stride_c, batch_size);
+    omatadd_batch_postcondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                                beta, b, ldb, stride_b, c, ldc, stride_c, batch_size);
+}
+
+// USM APIs
+
+sycl::event syr2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 float alpha, const float *x, std::int64_t incx, const float *y, std::int64_t incy,
+                 float *a, std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syr2(
+        selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    syr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
+                       dependencies);
+    return done;
+}
+
+sycl::event syr2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 double alpha, const double *x, std::int64_t incx, const double *y,
+                 std::int64_t incy, double *a, std::int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
+    syr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syr2(
+        selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    syr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
+                       dependencies);
+    return done;
+}
+
+sycl::event scal(backend_selector<backend::syclblas> selector, std::int64_t n, float alpha,
+                 float *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
+                                                         dependencies);
+    scal_postcondition(selector.get_queue(), n, alpha, x, incx, dependencies);
+    return done;
+}
+
+sycl::event scal(backend_selector<backend::syclblas> selector, std::int64_t n, double alpha,
+                 double *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
+                                                         dependencies);
+    scal_postcondition(selector.get_queue(), n, alpha, x, incx, dependencies);
+    return done;
+}
+
+sycl::event scal(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 std::complex<float> alpha, std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
+                                                         dependencies);
+    scal_postcondition(selector.get_queue(), n, alpha, x, incx, dependencies);
+    return done;
+}
+
+sycl::event scal(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 std::complex<double> alpha, std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
+                                                         dependencies);
+    scal_postcondition(selector.get_queue(), n, alpha, x, incx, dependencies);
+    return done;
+}
+
+sycl::event scal(backend_selector<backend::syclblas> selector, std::int64_t n, float alpha,
+                 std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
+                                                         dependencies);
+    scal_postcondition(selector.get_queue(), n, alpha, x, incx, dependencies);
+    return done;
+}
+
+sycl::event scal(backend_selector<backend::syclblas> selector, std::int64_t n, double alpha,
+                 std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    scal_precondition(selector.get_queue(), n, alpha, x, incx, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::scal(selector.get_queue(), n, alpha, x, incx,
+                                                         dependencies);
+    scal_postcondition(selector.get_queue(), n, alpha, x, incx, dependencies);
+    return done;
+}
+
+sycl::event trmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trmv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
+    trmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event trmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trmv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
+    trmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event trmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
+                 std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trmv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
+    trmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event trmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const std::complex<double> *a, std::int64_t lda,
+                 std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    trmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trmv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
+    trmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tpmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
+                                                         unit_diag, n, a, x, incx, dependencies);
+    tpmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tpmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
+                                                         unit_diag, n, a, x, incx, dependencies);
+    tpmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tpmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const std::complex<float> *a,
+                 std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
+                                                         unit_diag, n, a, x, incx, dependencies);
+    tpmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tpmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const std::complex<double> *a,
+                 std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    tpmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tpmv(selector.get_queue(), upper_lower, trans,
+                                                         unit_diag, n, a, x, incx, dependencies);
+    tpmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event spr(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                float alpha, const float *x, std::int64_t incx, float *a,
+                const std::vector<sycl::event> &dependencies) {
+    spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha,
+                                                        x, incx, a, dependencies);
+    spr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
+    return done;
+}
+
+sycl::event spr(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                double alpha, const double *x, std::int64_t incx, double *a,
+                const std::vector<sycl::event> &dependencies) {
+    spr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::spr(selector.get_queue(), upper_lower, n, alpha,
+                                                        x, incx, a, dependencies);
+    spr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
+    return done;
+}
+
+sycl::event hpmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a,
+                 const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::hpmv(
+        selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy, dependencies);
+    hpmv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
+                       dependencies);
+    return done;
+}
+
+sycl::event hpmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a,
+                 const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    hpmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::hpmv(
+        selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy, dependencies);
+    hpmv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
+                       dependencies);
+    return done;
+}
+
+sycl::event syrk(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
+                 float beta, float *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syrk(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
+    syrk_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
+                       dependencies);
+    return done;
+}
+
+sycl::event syrk(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
+                 double beta, double *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syrk(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
+    syrk_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
+                       dependencies);
+    return done;
+}
+
+sycl::event syrk(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                 const std::complex<float> *a, std::int64_t lda, std::complex<float> beta,
+                 std::complex<float> *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syrk(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
+    syrk_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
+                       dependencies);
+    return done;
+}
+
+sycl::event syrk(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                 const std::complex<double> *a, std::int64_t lda, std::complex<double> beta,
+                 std::complex<double> *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    syrk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syrk(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
+    syrk_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
+                       dependencies);
+    return done;
+}
+
+sycl::event syrk_batch(backend_selector<backend::syclblas> selector, uplo *upper_lower,
+                       transpose *trans, std::int64_t *n, std::int64_t *k, float *alpha,
+                       const float **a, std::int64_t *lda, float *beta, float **c,
+                       std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
+                            ldc, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syrk_batch(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, group_count,
+        group_size, dependencies);
+    syrk_batch_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
+                             ldc, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event syrk_batch(backend_selector<backend::syclblas> selector, uplo *upper_lower,
+                       transpose *trans, std::int64_t *n, std::int64_t *k, double *alpha,
+                       const double **a, std::int64_t *lda, double *beta, double **c,
+                       std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
+                            ldc, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syrk_batch(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, group_count,
+        group_size, dependencies);
+    syrk_batch_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
+                             ldc, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event syrk_batch(backend_selector<backend::syclblas> selector, uplo *upper_lower,
+                       transpose *trans, std::int64_t *n, std::int64_t *k,
+                       std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
+                       std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
+                            ldc, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syrk_batch(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, group_count,
+        group_size, dependencies);
+    syrk_batch_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
+                             ldc, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event syrk_batch(backend_selector<backend::syclblas> selector, uplo *upper_lower,
+                       transpose *trans, std::int64_t *n, std::int64_t *k,
+                       std::complex<double> *alpha, const std::complex<double> **a,
+                       std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
+                       std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
+                            ldc, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syrk_batch(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, group_count,
+        group_size, dependencies);
+    syrk_batch_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c,
+                             ldc, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event syrk_batch(backend_selector<backend::syclblas> selector, uplo upper_lower,
+                       transpose trans, std::int64_t n, std::int64_t k, float alpha, const float *a,
+                       std::int64_t lda, std::int64_t stride_a, float beta, float *c,
+                       std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
+                            beta, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syrk_batch(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc,
+        stride_c, batch_size, dependencies);
+    syrk_batch_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda,
+                             stride_a, beta, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}
+
+sycl::event syrk_batch(backend_selector<backend::syclblas> selector, uplo upper_lower,
+                       transpose trans, std::int64_t n, std::int64_t k, double alpha,
+                       const double *a, std::int64_t lda, std::int64_t stride_a, double beta,
+                       double *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
+                            beta, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syrk_batch(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc,
+        stride_c, batch_size, dependencies);
+    syrk_batch_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda,
+                             stride_a, beta, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}
+
+sycl::event syrk_batch(backend_selector<backend::syclblas> selector, uplo upper_lower,
+                       transpose trans, std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                       const std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
+                       std::complex<float> beta, std::complex<float> *c, std::int64_t ldc,
+                       std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
+                            beta, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syrk_batch(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc,
+        stride_c, batch_size, dependencies);
+    syrk_batch_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda,
+                             stride_a, beta, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}
+
+sycl::event syrk_batch(backend_selector<backend::syclblas> selector, uplo upper_lower,
+                       transpose trans, std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                       const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
+                       std::complex<double> beta, std::complex<double> *c, std::int64_t ldc,
+                       std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    syrk_batch_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a,
+                            beta, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syrk_batch(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, stride_a, beta, c, ldc,
+        stride_c, batch_size, dependencies);
+    syrk_batch_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda,
+                             stride_a, beta, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}
+
+sycl::event her2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
+                 const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
+                 std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::her2(
+        selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    her2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
+                       dependencies);
+    return done;
+}
+
+sycl::event her2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
+                 const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
+                 std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    her2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::her2(
+        selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    her2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a, lda,
+                       dependencies);
+    return done;
+}
+
+sycl::event hbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
+                 std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
+                 std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                      incy, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::hbmv(selector.get_queue(), upper_lower, n, k, alpha, a,
+                                                 lda, x, incx, beta, y, incy, dependencies);
+    hbmv_postcondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                       incy, dependencies);
+    return done;
+}
+
+sycl::event hbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
+                 std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
+                 std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    hbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                      incy, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::hbmv(selector.get_queue(), upper_lower, n, k, alpha, a,
+                                                 lda, x, incx, beta, y, incy, dependencies);
+    hbmv_postcondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                       incy, dependencies);
+    return done;
+}
+
+sycl::event rot(backend_selector<backend::syclblas> selector, std::int64_t n,
+                std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
+                std::int64_t incy, float c, float s, const std::vector<sycl::event> &dependencies) {
+    rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy,
+                                                        c, s, dependencies);
+    rot_postcondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
+    return done;
+}
+
+sycl::event rot(backend_selector<backend::syclblas> selector, std::int64_t n,
+                std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
+                std::int64_t incy, double c, double s,
+                const std::vector<sycl::event> &dependencies) {
+    rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy,
+                                                        c, s, dependencies);
+    rot_postcondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
+    return done;
+}
+
+sycl::event rot(backend_selector<backend::syclblas> selector, std::int64_t n, float *x,
+                std::int64_t incx, float *y, std::int64_t incy, float c, float s,
+                const std::vector<sycl::event> &dependencies) {
+    rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy,
+                                                        c, s, dependencies);
+    rot_postcondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
+    return done;
+}
+
+sycl::event rot(backend_selector<backend::syclblas> selector, std::int64_t n, double *x,
+                std::int64_t incx, double *y, std::int64_t incy, double c, double s,
+                const std::vector<sycl::event> &dependencies) {
+    rot_precondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::rot(selector.get_queue(), n, x, incx, y, incy,
+                                                        c, s, dependencies);
+    rot_postcondition(selector.get_queue(), n, x, incx, y, incy, c, s, dependencies);
+    return done;
+}
+
+sycl::event axpy(backend_selector<backend::syclblas> selector, std::int64_t n, float alpha,
+                 const float *x, std::int64_t incx, float *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
+                                                         incy, dependencies);
+    axpy_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
+    return done;
+}
+
+sycl::event axpy(backend_selector<backend::syclblas> selector, std::int64_t n, double alpha,
+                 const double *x, std::int64_t incx, double *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
+                                                         incy, dependencies);
+    axpy_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
+    return done;
+}
+
+sycl::event axpy(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
+                 std::complex<float> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
+                                                         incy, dependencies);
+    axpy_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
+    return done;
+}
+
+sycl::event axpy(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
+                 std::complex<double> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    axpy_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpy(selector.get_queue(), n, alpha, x, incx, y,
+                                                         incy, dependencies);
+    axpy_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy, dependencies);
+    return done;
+}
+
+sycl::event axpy_batch(backend_selector<backend::syclblas> selector, std::int64_t *n, float *alpha,
+                       const float **x, std::int64_t *incx, float **y, std::int64_t *incy,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
+                            group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpy_batch(
+        selector.get_queue(), n, alpha, x, incx, y, incy, group_count, group_size, dependencies);
+    axpy_batch_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
+                             group_size, dependencies);
+    return done;
+}
+
+sycl::event axpy_batch(backend_selector<backend::syclblas> selector, std::int64_t *n, double *alpha,
+                       const double **x, std::int64_t *incx, double **y, std::int64_t *incy,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
+                            group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpy_batch(
+        selector.get_queue(), n, alpha, x, incx, y, incy, group_count, group_size, dependencies);
+    axpy_batch_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
+                             group_size, dependencies);
+    return done;
+}
+
+sycl::event axpy_batch(backend_selector<backend::syclblas> selector, std::int64_t *n,
+                       std::complex<float> *alpha, const std::complex<float> **x,
+                       std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
+                            group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpy_batch(
+        selector.get_queue(), n, alpha, x, incx, y, incy, group_count, group_size, dependencies);
+    axpy_batch_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
+                             group_size, dependencies);
+    return done;
+}
+
+sycl::event axpy_batch(backend_selector<backend::syclblas> selector, std::int64_t *n,
+                       std::complex<double> *alpha, const std::complex<double> **x,
+                       std::int64_t *incx, std::complex<double> **y, std::int64_t *incy,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
+                            group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpy_batch(
+        selector.get_queue(), n, alpha, x, incx, y, incy, group_count, group_size, dependencies);
+    axpy_batch_postcondition(selector.get_queue(), n, alpha, x, incx, y, incy, group_count,
+                             group_size, dependencies);
+    return done;
+}
+
+sycl::event axpy_batch(backend_selector<backend::syclblas> selector, std::int64_t n, float alpha,
+                       const float *x, std::int64_t incx, std::int64_t stridex, float *y,
+                       std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                            batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
+                                                               incx, stridex, y, incy, stridey,
+                                                               batch_size, dependencies);
+    axpy_batch_postcondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                             batch_size, dependencies);
+    return done;
+}
+
+sycl::event axpy_batch(backend_selector<backend::syclblas> selector, std::int64_t n, double alpha,
+                       const double *x, std::int64_t incx, std::int64_t stridex, double *y,
+                       std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                            batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
+                                                               incx, stridex, y, incy, stridey,
+                                                               batch_size, dependencies);
+    axpy_batch_postcondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                             batch_size, dependencies);
+    return done;
+}
+
+sycl::event axpy_batch(backend_selector<backend::syclblas> selector, std::int64_t n,
+                       std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
+                       std::int64_t stridex, std::complex<float> *y, std::int64_t incy,
+                       std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                            batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
+                                                               incx, stridex, y, incy, stridey,
+                                                               batch_size, dependencies);
+    axpy_batch_postcondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                             batch_size, dependencies);
+    return done;
+}
+
+sycl::event axpy_batch(backend_selector<backend::syclblas> selector, std::int64_t n,
+                       std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
+                       std::int64_t stridex, std::complex<double> *y, std::int64_t incy,
+                       std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    axpy_batch_precondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                            batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpy_batch(selector.get_queue(), n, alpha, x,
+                                                               incx, stridex, y, incy, stridey,
+                                                               batch_size, dependencies);
+    axpy_batch_postcondition(selector.get_queue(), n, alpha, x, incx, stridex, y, incy, stridey,
+                             batch_size, dependencies);
+    return done;
+}
+
+sycl::event axpby(backend_selector<backend::syclblas> selector, std::int64_t n, float alpha,
+                  const float *x, std::int64_t incx, const float beta, float *y, std::int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
+    axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
+                                                          beta, y, incy, dependencies);
+    axpby_postcondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
+    return done;
+}
+
+sycl::event axpby(backend_selector<backend::syclblas> selector, std::int64_t n, double alpha,
+                  const double *x, std::int64_t incx, const double beta, double *y,
+                  std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
+                                                          beta, y, incy, dependencies);
+    axpby_postcondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
+    return done;
+}
+
+sycl::event axpby(backend_selector<backend::syclblas> selector, std::int64_t n,
+                  std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
+                  const std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
+    axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
+                                                          beta, y, incy, dependencies);
+    axpby_postcondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
+    return done;
+}
+
+sycl::event axpby(backend_selector<backend::syclblas> selector, std::int64_t n,
+                  std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
+                  const std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
+    axpby_precondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::axpby(selector.get_queue(), n, alpha, x, incx,
+                                                          beta, y, incy, dependencies);
+    axpby_postcondition(selector.get_queue(), n, alpha, x, incx, beta, y, incy, dependencies);
+    return done;
+}
+
+sycl::event gerc(backend_selector<backend::syclblas> selector, std::int64_t m, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
+                 const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
+                 std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
+                                                         y, incy, a, lda, dependencies);
+    gerc_postcondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    return done;
+}
+
+sycl::event gerc(backend_selector<backend::syclblas> selector, std::int64_t m, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
+                 const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
+                 std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    gerc_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gerc(selector.get_queue(), m, n, alpha, x, incx,
+                                                         y, incy, a, lda, dependencies);
+    gerc_postcondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    return done;
+}
+
+sycl::event syr2k(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                  std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
+                  const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
+    syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syr2k(selector.get_queue(), upper_lower, trans,
+                                                          n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+                                                          dependencies);
+    syr2k_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                        c, ldc, dependencies);
+    return done;
+}
+
+sycl::event syr2k(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                  std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
+                  const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
+    syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syr2k(selector.get_queue(), upper_lower, trans,
+                                                          n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+                                                          dependencies);
+    syr2k_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                        c, ldc, dependencies);
+    return done;
+}
+
+sycl::event syr2k(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                  std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                  const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
+                  std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
+                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syr2k(selector.get_queue(), upper_lower, trans,
+                                                          n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+                                                          dependencies);
+    syr2k_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                        c, ldc, dependencies);
+    return done;
+}
+
+sycl::event syr2k(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                  std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                  const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
+                  std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
+                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    syr2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syr2k(selector.get_queue(), upper_lower, trans,
+                                                          n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+                                                          dependencies);
+    syr2k_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                        c, ldc, dependencies);
+    return done;
+}
+
+sycl::event gemv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                 std::int64_t n, float alpha, const float *a, std::int64_t lda, const float *x,
+                 std::int64_t incx, float beta, float *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemv(
+        selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
+    gemv_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
+                       dependencies);
+    return done;
+}
+
+sycl::event gemv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                 std::int64_t n, double alpha, const double *a, std::int64_t lda, const double *x,
+                 std::int64_t incx, double beta, double *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemv(
+        selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
+    gemv_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
+                       dependencies);
+    return done;
+}
+
+sycl::event gemv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                 std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
+                 std::int64_t lda, const std::complex<float> *x, std::int64_t incx,
+                 std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemv(
+        selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
+    gemv_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
+                       dependencies);
+    return done;
+}
+
+sycl::event gemv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                 std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
+                 std::int64_t lda, const std::complex<double> *x, std::int64_t incx,
+                 std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    gemv_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemv(
+        selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
+    gemv_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy,
+                       dependencies);
+    return done;
+}
+
+sycl::event gemv_batch(backend_selector<backend::syclblas> selector, transpose trans,
+                       std::int64_t m, std::int64_t n, float alpha, const float *a,
+                       std::int64_t lda, std::int64_t stridea, const float *x, std::int64_t incx,
+                       std::int64_t stridex, float beta, float *y, std::int64_t incy,
+                       std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                            stridex, beta, y, incy, stridey, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemv_batch(
+        selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y, incy,
+        stridey, batch_size, dependencies);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                             stridex, beta, y, incy, stridey, batch_size, dependencies);
+    return done;
+}
+
+sycl::event gemv_batch(backend_selector<backend::syclblas> selector, transpose trans,
+                       std::int64_t m, std::int64_t n, double alpha, const double *a,
+                       std::int64_t lda, std::int64_t stridea, const double *x, std::int64_t incx,
+                       std::int64_t stridex, double beta, double *y, std::int64_t incy,
+                       std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                            stridex, beta, y, incy, stridey, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemv_batch(
+        selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y, incy,
+        stridey, batch_size, dependencies);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                             stridex, beta, y, incy, stridey, batch_size, dependencies);
+    return done;
+}
+
+sycl::event gemv_batch(backend_selector<backend::syclblas> selector, transpose trans,
+                       std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                       const std::complex<float> *a, std::int64_t lda, std::int64_t stridea,
+                       const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
+                       std::complex<float> beta, std::complex<float> *y, std::int64_t incy,
+                       std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                            stridex, beta, y, incy, stridey, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemv_batch(
+        selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y, incy,
+        stridey, batch_size, dependencies);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                             stridex, beta, y, incy, stridey, batch_size, dependencies);
+    return done;
+}
+
+sycl::event gemv_batch(backend_selector<backend::syclblas> selector, transpose trans,
+                       std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                       const std::complex<double> *a, std::int64_t lda, std::int64_t stridea,
+                       const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
+                       std::complex<double> beta, std::complex<double> *y, std::int64_t incy,
+                       std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                            stridex, beta, y, incy, stridey, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemv_batch(
+        selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx, stridex, beta, y, incy,
+        stridey, batch_size, dependencies);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stridea, x, incx,
+                             stridex, beta, y, incy, stridey, batch_size, dependencies);
+    return done;
+}
+
+sycl::event gemv_batch(backend_selector<backend::syclblas> selector, transpose *trans,
+                       std::int64_t *m, std::int64_t *n, float *alpha, const float **a,
+                       std::int64_t *lda, const float **x, std::int64_t *incx, float *beta,
+                       float **y, std::int64_t *incy, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
+                            incy, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemv_batch(
+        selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count,
+        group_size, dependencies);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
+                             incy, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event gemv_batch(backend_selector<backend::syclblas> selector, transpose *trans,
+                       std::int64_t *m, std::int64_t *n, double *alpha, const double **a,
+                       std::int64_t *lda, const double **x, std::int64_t *incx, double *beta,
+                       double **y, std::int64_t *incy, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
+                            incy, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemv_batch(
+        selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count,
+        group_size, dependencies);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
+                             incy, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event gemv_batch(backend_selector<backend::syclblas> selector, transpose *trans,
+                       std::int64_t *m, std::int64_t *n, std::complex<float> *alpha,
+                       const std::complex<float> **a, std::int64_t *lda,
+                       const std::complex<float> **x, std::int64_t *incx, std::complex<float> *beta,
+                       std::complex<float> **y, std::int64_t *incy, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
+                            incy, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemv_batch(
+        selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count,
+        group_size, dependencies);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
+                             incy, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event gemv_batch(backend_selector<backend::syclblas> selector, transpose *trans,
+                       std::int64_t *m, std::int64_t *n, std::complex<double> *alpha,
+                       const std::complex<double> **a, std::int64_t *lda,
+                       const std::complex<double> **x, std::int64_t *incx,
+                       std::complex<double> *beta, std::complex<double> **y, std::int64_t *incy,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemv_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
+                            incy, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemv_batch(
+        selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y, incy, group_count,
+        group_size, dependencies);
+    gemv_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, x, incx, beta, y,
+                             incy, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event dgmm_batch(backend_selector<backend::syclblas> selector, side left_right,
+                       std::int64_t m, std::int64_t n, const float *a, std::int64_t lda,
+                       std::int64_t stridea, const float *x, std::int64_t incx,
+                       std::int64_t stridex, float *c, std::int64_t ldc, std::int64_t stridec,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                            stridex, c, ldc, stridec, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dgmm_batch(
+        selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc, stridec,
+        batch_size, dependencies);
+    dgmm_batch_postcondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                             stridex, c, ldc, stridec, batch_size, dependencies);
+    return done;
+}
+
+sycl::event dgmm_batch(backend_selector<backend::syclblas> selector, side left_right,
+                       std::int64_t m, std::int64_t n, const double *a, std::int64_t lda,
+                       std::int64_t stridea, const double *x, std::int64_t incx,
+                       std::int64_t stridex, double *c, std::int64_t ldc, std::int64_t stridec,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                            stridex, c, ldc, stridec, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dgmm_batch(
+        selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc, stridec,
+        batch_size, dependencies);
+    dgmm_batch_postcondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                             stridex, c, ldc, stridec, batch_size, dependencies);
+    return done;
+}
+
+sycl::event dgmm_batch(backend_selector<backend::syclblas> selector, side left_right,
+                       std::int64_t m, std::int64_t n, const std::complex<float> *a,
+                       std::int64_t lda, std::int64_t stridea, const std::complex<float> *x,
+                       std::int64_t incx, std::int64_t stridex, std::complex<float> *c,
+                       std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                            stridex, c, ldc, stridec, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dgmm_batch(
+        selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc, stridec,
+        batch_size, dependencies);
+    dgmm_batch_postcondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                             stridex, c, ldc, stridec, batch_size, dependencies);
+    return done;
+}
+
+sycl::event dgmm_batch(backend_selector<backend::syclblas> selector, side left_right,
+                       std::int64_t m, std::int64_t n, const std::complex<double> *a,
+                       std::int64_t lda, std::int64_t stridea, const std::complex<double> *x,
+                       std::int64_t incx, std::int64_t stridex, std::complex<double> *c,
+                       std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                            stridex, c, ldc, stridec, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dgmm_batch(
+        selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx, stridex, c, ldc, stridec,
+        batch_size, dependencies);
+    dgmm_batch_postcondition(selector.get_queue(), left_right, m, n, a, lda, stridea, x, incx,
+                             stridex, c, ldc, stridec, batch_size, dependencies);
+    return done;
+}
+
+sycl::event dgmm_batch(backend_selector<backend::syclblas> selector, side *left_right,
+                       std::int64_t *m, std::int64_t *n, const float **a, std::int64_t *lda,
+                       const float **x, std::int64_t *incx, float **c, std::int64_t *ldc,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
+                            group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dgmm_batch(
+        selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc, group_count, group_size,
+        dependencies);
+    dgmm_batch_postcondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
+                             group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event dgmm_batch(backend_selector<backend::syclblas> selector, side *left_right,
+                       std::int64_t *m, std::int64_t *n, const double **a, std::int64_t *lda,
+                       const double **x, std::int64_t *incx, double **c, std::int64_t *ldc,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
+                            group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dgmm_batch(
+        selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc, group_count, group_size,
+        dependencies);
+    dgmm_batch_postcondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
+                             group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event dgmm_batch(backend_selector<backend::syclblas> selector, side *left_right,
+                       std::int64_t *m, std::int64_t *n, const std::complex<float> **a,
+                       std::int64_t *lda, const std::complex<float> **x, std::int64_t *incx,
+                       std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
+                            group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dgmm_batch(
+        selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc, group_count, group_size,
+        dependencies);
+    dgmm_batch_postcondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
+                             group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event dgmm_batch(backend_selector<backend::syclblas> selector, side *left_right,
+                       std::int64_t *m, std::int64_t *n, const std::complex<double> **a,
+                       std::int64_t *lda, const std::complex<double> **x, std::int64_t *incx,
+                       std::complex<double> **c, std::int64_t *ldc, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    dgmm_batch_precondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
+                            group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dgmm_batch(
+        selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc, group_count, group_size,
+        dependencies);
+    dgmm_batch_postcondition(selector.get_queue(), left_right, m, n, a, lda, x, incx, c, ldc,
+                             group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event her(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                float alpha, const std::complex<float> *x, std::int64_t incx,
+                std::complex<float> *a, std::int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
+    her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::her(selector.get_queue(), upper_lower, n, alpha,
+                                                        x, incx, a, lda, dependencies);
+    her_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
+    return done;
+}
+
+sycl::event her(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                double alpha, const std::complex<double> *x, std::int64_t incx,
+                std::complex<double> *a, std::int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
+    her_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::her(selector.get_queue(), upper_lower, n, alpha,
+                                                        x, incx, a, lda, dependencies);
+    her_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
+    return done;
+}
+
+sycl::event hpr(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                float alpha, const std::complex<float> *x, std::int64_t incx,
+                std::complex<float> *a, const std::vector<sycl::event> &dependencies) {
+    hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
+                                                        x, incx, a, dependencies);
+    hpr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
+    return done;
+}
+
+sycl::event hpr(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                double alpha, const std::complex<double> *x, std::int64_t incx,
+                std::complex<double> *a, const std::vector<sycl::event> &dependencies) {
+    hpr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::hpr(selector.get_queue(), upper_lower, n, alpha,
+                                                        x, incx, a, dependencies);
+    hpr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, dependencies);
+    return done;
+}
+
+sycl::event iamin(backend_selector<backend::syclblas> selector, std::int64_t n, const float *x,
+                  std::int64_t incx, std::int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
+    iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
+                                                          dependencies);
+    iamin_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event iamin(backend_selector<backend::syclblas> selector, std::int64_t n, const double *x,
+                  std::int64_t incx, std::int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
+    iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
+                                                          dependencies);
+    iamin_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event iamin(backend_selector<backend::syclblas> selector, std::int64_t n,
+                  const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
+    iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
+                                                          dependencies);
+    iamin_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event iamin(backend_selector<backend::syclblas> selector, std::int64_t n,
+                  const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
+    iamin_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
+                                                          dependencies);
+    iamin_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event gemm_batch(backend_selector<backend::syclblas> selector, transpose *transa,
+                       transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
+                       sycl::half *alpha, const sycl::half **a, std::int64_t *lda,
+                       const sycl::half **b, std::int64_t *ldb, sycl::half *beta, sycl::half **c,
+                       std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
+                            beta, c, ldc, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(
+        selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+        group_count, group_size, dependencies);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
+                             beta, c, ldc, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event gemm_batch(backend_selector<backend::syclblas> selector, transpose *transa,
+                       transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
+                       float *alpha, const float **a, std::int64_t *lda, const float **b,
+                       std::int64_t *ldb, float *beta, float **c, std::int64_t *ldc,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
+                            beta, c, ldc, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(
+        selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+        group_count, group_size, dependencies);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
+                             beta, c, ldc, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event gemm_batch(backend_selector<backend::syclblas> selector, transpose *transa,
+                       transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
+                       double *alpha, const double **a, std::int64_t *lda, const double **b,
+                       std::int64_t *ldb, double *beta, double **c, std::int64_t *ldc,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
+                            beta, c, ldc, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(
+        selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+        group_count, group_size, dependencies);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
+                             beta, c, ldc, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event gemm_batch(backend_selector<backend::syclblas> selector, transpose *transa,
+                       transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
+                       std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
+                       const std::complex<float> **b, std::int64_t *ldb, std::complex<float> *beta,
+                       std::complex<float> **c, std::int64_t *ldc, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
+                            beta, c, ldc, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(
+        selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+        group_count, group_size, dependencies);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
+                             beta, c, ldc, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event gemm_batch(backend_selector<backend::syclblas> selector, transpose *transa,
+                       transpose *transb, std::int64_t *m, std::int64_t *n, std::int64_t *k,
+                       std::complex<double> *alpha, const std::complex<double> **a,
+                       std::int64_t *lda, const std::complex<double> **b, std::int64_t *ldb,
+                       std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
+                            beta, c, ldc, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(
+        selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+        group_count, group_size, dependencies);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb,
+                             beta, c, ldc, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event gemm_batch(backend_selector<backend::syclblas> selector, transpose transa,
+                       transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                       sycl::half alpha, const sycl::half *a, std::int64_t lda,
+                       std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+                       std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc,
+                       std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                            b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(
+        selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b,
+        beta, c, ldc, stride_c, batch_size, dependencies);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}
+
+sycl::event gemm_batch(backend_selector<backend::syclblas> selector, transpose transa,
+                       transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                       float alpha, const float *a, std::int64_t lda, std::int64_t stride_a,
+                       const float *b, std::int64_t ldb, std::int64_t stride_b, float beta,
+                       float *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                            b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(
+        selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b,
+        beta, c, ldc, stride_c, batch_size, dependencies);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}
+
+sycl::event gemm_batch(backend_selector<backend::syclblas> selector, transpose transa,
+                       transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                       double alpha, const double *a, std::int64_t lda, std::int64_t stride_a,
+                       const double *b, std::int64_t ldb, std::int64_t stride_b, double beta,
+                       double *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                            b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(
+        selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b,
+        beta, c, ldc, stride_c, batch_size, dependencies);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}
+
+sycl::event gemm_batch(backend_selector<backend::syclblas> selector, transpose transa,
+                       transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                       std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
+                       std::int64_t stride_a, const std::complex<float> *b, std::int64_t ldb,
+                       std::int64_t stride_b, std::complex<float> beta, std::complex<float> *c,
+                       std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                            b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(
+        selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b,
+        beta, c, ldc, stride_c, batch_size, dependencies);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}
+
+sycl::event gemm_batch(backend_selector<backend::syclblas> selector, transpose transa,
+                       transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
+                       std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
+                       std::int64_t stride_a, const std::complex<double> *b, std::int64_t ldb,
+                       std::int64_t stride_b, std::complex<double> beta, std::complex<double> *c,
+                       std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    gemm_batch_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                            b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_batch(
+        selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a, b, ldb, stride_b,
+        beta, c, ldc, stride_c, batch_size, dependencies);
+    gemm_batch_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, stride_a,
+                             b, ldb, stride_b, beta, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}
+
+sycl::event spmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 float alpha, const float *a, const float *x, std::int64_t incx, float beta,
+                 float *y, std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::spmv(
+        selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy, dependencies);
+    spmv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
+                       dependencies);
+    return done;
+}
+
+sycl::event spmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 double alpha, const double *a, const double *x, std::int64_t incx, double beta,
+                 double *y, std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    spmv_precondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::spmv(
+        selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy, dependencies);
+    spmv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, x, incx, beta, y, incy,
+                       dependencies);
+    return done;
+}
+
+sycl::event swap(backend_selector<backend::syclblas> selector, std::int64_t n, float *x,
+                 std::int64_t incx, float *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
+                                                         dependencies);
+    swap_postcondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    return done;
+}
+
+sycl::event swap(backend_selector<backend::syclblas> selector, std::int64_t n, double *x,
+                 std::int64_t incx, double *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
+                                                         dependencies);
+    swap_postcondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    return done;
+}
+
+sycl::event swap(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
+                                                         dependencies);
+    swap_postcondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    return done;
+}
+
+sycl::event swap(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    swap_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::swap(selector.get_queue(), n, x, incx, y, incy,
+                                                         dependencies);
+    swap_postcondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    return done;
+}
+
+sycl::event geru(backend_selector<backend::syclblas> selector, std::int64_t m, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
+                 const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
+                 std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
+                                                         y, incy, a, lda, dependencies);
+    geru_postcondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    return done;
+}
+
+sycl::event geru(backend_selector<backend::syclblas> selector, std::int64_t m, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
+                 const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
+                 std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    geru_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::geru(selector.get_queue(), m, n, alpha, x, incx,
+                                                         y, incy, a, lda, dependencies);
+    geru_postcondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    return done;
+}
+
+sycl::event nrm2(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 const std::complex<float> *x, std::int64_t incx, float *result,
+                 const std::vector<sycl::event> &dependencies) {
+    nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
+                                                         dependencies);
+    nrm2_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event nrm2(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 const std::complex<double> *x, std::int64_t incx, double *result,
+                 const std::vector<sycl::event> &dependencies) {
+    nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
+                                                         dependencies);
+    nrm2_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event nrm2(backend_selector<backend::syclblas> selector, std::int64_t n, const float *x,
+                 std::int64_t incx, float *result, const std::vector<sycl::event> &dependencies) {
+    nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
+                                                         dependencies);
+    nrm2_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event nrm2(backend_selector<backend::syclblas> selector, std::int64_t n, const double *x,
+                 std::int64_t incx, double *result, const std::vector<sycl::event> &dependencies) {
+    nrm2_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::nrm2(selector.get_queue(), n, x, incx, result,
+                                                         dependencies);
+    nrm2_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
+                 std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k,
+                                                 alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    return done;
+}
+
+sycl::event gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
+                 std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k,
+                                                 alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    return done;
+}
+
+sycl::event gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                 const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
+                 std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k,
+                                                 alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    return done;
+}
+
+sycl::event gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                 const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
+                 std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k,
+                                                 alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    return done;
+}
+
+sycl::event gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                 const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                 sycl::half beta, sycl::half *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k,
+                                                 alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    return done;
+}
+
+sycl::event gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const sycl::half *a,
+                 std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta, float *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k,
+                                                 alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    return done;
+}
+
+sycl::event gemm(backend_selector<backend::syclblas> selector, transpose transa, transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const bfloat16 *a,
+                 std::int64_t lda, const bfloat16 *b, std::int64_t ldb, float beta, float *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    gemm_precondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                      ldc, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::gemm(selector.get_queue(), transa, transb, m, n, k,
+                                                 alpha, a, lda, b, ldb, beta, c, ldc, dependencies);
+    gemm_postcondition(selector.get_queue(), transa, transb, m, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    return done;
+}
+
+sycl::event gemm_bias(backend_selector<backend::syclblas> selector, transpose transa,
+                      transpose transb, offset offsetc, std::int64_t m, std::int64_t n,
+                      std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
+                      std::int8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
+                      float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
+    gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                           ao, b, ldb, bo, beta, c, ldc, co, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_bias(
+        selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo, beta,
+        c, ldc, co, dependencies);
+    gemm_bias_postcondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
+    return done;
+}
+
+sycl::event gemm_bias(backend_selector<backend::syclblas> selector, transpose transa,
+                      transpose transb, offset offsetc, std::int64_t m, std::int64_t n,
+                      std::int64_t k, float alpha, const std::int8_t *a, std::int64_t lda,
+                      std::int8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
+                      float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
+    gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                           ao, b, ldb, bo, beta, c, ldc, co, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_bias(
+        selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo, beta,
+        c, ldc, co, dependencies);
+    gemm_bias_postcondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
+    return done;
+}
+
+sycl::event gemm_bias(backend_selector<backend::syclblas> selector, transpose transa,
+                      transpose transb, offset offsetc, std::int64_t m, std::int64_t n,
+                      std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
+                      std::uint8_t ao, const std::int8_t *b, std::int64_t ldb, std::int8_t bo,
+                      float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
+    gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                           ao, b, ldb, bo, beta, c, ldc, co, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_bias(
+        selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo, beta,
+        c, ldc, co, dependencies);
+    gemm_bias_postcondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
+    return done;
+}
+
+sycl::event gemm_bias(backend_selector<backend::syclblas> selector, transpose transa,
+                      transpose transb, offset offsetc, std::int64_t m, std::int64_t n,
+                      std::int64_t k, float alpha, const std::uint8_t *a, std::int64_t lda,
+                      std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb, std::uint8_t bo,
+                      float beta, std::int32_t *c, std::int64_t ldc, const std::int32_t *co,
+                      const std::vector<sycl::event> &dependencies) {
+    gemm_bias_precondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                           ao, b, ldb, bo, beta, c, ldc, co, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemm_bias(
+        selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda, ao, b, ldb, bo, beta,
+        c, ldc, co, dependencies);
+    gemm_bias_postcondition(selector.get_queue(), transa, transb, offsetc, m, n, k, alpha, a, lda,
+                            ao, b, ldb, bo, beta, c, ldc, co, dependencies);
+    return done;
+}
+
+sycl::event herk(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a,
+                 std::int64_t lda, float beta, std::complex<float> *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::herk(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
+    herk_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
+                       dependencies);
+    return done;
+}
+
+sycl::event herk(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a,
+                 std::int64_t lda, double beta, std::complex<double> *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    herk_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::herk(
+        selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc, dependencies);
+    herk_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, beta, c, ldc,
+                       dependencies);
+    return done;
+}
+
+sycl::event ger(backend_selector<backend::syclblas> selector, std::int64_t m, std::int64_t n,
+                float alpha, const float *x, std::int64_t incx, const float *y, std::int64_t incy,
+                float *a, std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx,
+                                                        y, incy, a, lda, dependencies);
+    ger_postcondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    return done;
+}
+
+sycl::event ger(backend_selector<backend::syclblas> selector, std::int64_t m, std::int64_t n,
+                double alpha, const double *x, std::int64_t incx, const double *y,
+                std::int64_t incy, double *a, std::int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
+    ger_precondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::ger(selector.get_queue(), m, n, alpha, x, incx,
+                                                        y, incy, a, lda, dependencies);
+    ger_postcondition(selector.get_queue(), m, n, alpha, x, incx, y, incy, a, lda, dependencies);
+    return done;
+}
+
+sycl::event trsm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
+                 const float *a, std::int64_t lda, float *b, std::int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
+    trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsm(selector.get_queue(), left_right,
+                                                         upper_lower, trans, unit_diag, m, n, alpha,
+                                                         a, lda, b, ldb, dependencies);
+    trsm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb, dependencies);
+    return done;
+}
+
+sycl::event trsm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
+                 const double *a, std::int64_t lda, double *b, std::int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
+    trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsm(selector.get_queue(), left_right,
+                                                         upper_lower, trans, unit_diag, m, n, alpha,
+                                                         a, lda, b, ldb, dependencies);
+    trsm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb, dependencies);
+    return done;
+}
+
+sycl::event trsm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
+                 std::complex<float> *b, std::int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
+    trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsm(selector.get_queue(), left_right,
+                                                         upper_lower, trans, unit_diag, m, n, alpha,
+                                                         a, lda, b, ldb, dependencies);
+    trsm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb, dependencies);
+    return done;
+}
+
+sycl::event trsm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
+                 std::complex<double> *b, std::int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
+    trsm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsm(selector.get_queue(), left_right,
+                                                         upper_lower, trans, unit_diag, m, n, alpha,
+                                                         a, lda, b, ldb, dependencies);
+    trsm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb, dependencies);
+    return done;
+}
+
+sycl::event trsm_batch(backend_selector<backend::syclblas> selector, side left_right,
+                       uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
+                       std::int64_t n, float alpha, const float *a, std::int64_t lda,
+                       std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                            alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsm_batch(
+        selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
+        stride_a, b, ldb, stride_b, batch_size, dependencies);
+    trsm_batch_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
+    return done;
+}
+
+sycl::event trsm_batch(backend_selector<backend::syclblas> selector, side left_right,
+                       uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
+                       std::int64_t n, double alpha, const double *a, std::int64_t lda,
+                       std::int64_t stride_a, double *b, std::int64_t ldb, std::int64_t stride_b,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                            alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsm_batch(
+        selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
+        stride_a, b, ldb, stride_b, batch_size, dependencies);
+    trsm_batch_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
+    return done;
+}
+
+sycl::event trsm_batch(backend_selector<backend::syclblas> selector, side left_right,
+                       uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
+                       std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
+                       std::int64_t lda, std::int64_t stride_a, std::complex<float> *b,
+                       std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                            alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsm_batch(
+        selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
+        stride_a, b, ldb, stride_b, batch_size, dependencies);
+    trsm_batch_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
+    return done;
+}
+
+sycl::event trsm_batch(backend_selector<backend::syclblas> selector, side left_right,
+                       uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
+                       std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
+                       std::int64_t lda, std::int64_t stride_a, std::complex<double> *b,
+                       std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                            alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsm_batch(
+        selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda,
+        stride_a, b, ldb, stride_b, batch_size, dependencies);
+    trsm_batch_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                             alpha, a, lda, stride_a, b, ldb, stride_b, batch_size, dependencies);
+    return done;
+}
+
+sycl::event trsm_batch(backend_selector<backend::syclblas> selector, side *left_right,
+                       uplo *upper_lower, transpose *trans, diag *unit_diag, std::int64_t *m,
+                       std::int64_t *n, float *alpha, const float **a, std::int64_t *lda, float **b,
+                       std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                            alpha, a, lda, b, ldb, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsm_batch(
+        selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b,
+        ldb, group_count, group_size, dependencies);
+    trsm_batch_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event trsm_batch(backend_selector<backend::syclblas> selector, side *left_right,
+                       uplo *upper_lower, transpose *trans, diag *unit_diag, std::int64_t *m,
+                       std::int64_t *n, double *alpha, const double **a, std::int64_t *lda,
+                       double **b, std::int64_t *ldb, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                            alpha, a, lda, b, ldb, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsm_batch(
+        selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b,
+        ldb, group_count, group_size, dependencies);
+    trsm_batch_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event trsm_batch(backend_selector<backend::syclblas> selector, side *left_right,
+                       uplo *upper_lower, transpose *trans, diag *unit_diag, std::int64_t *m,
+                       std::int64_t *n, std::complex<float> *alpha, const std::complex<float> **a,
+                       std::int64_t *lda, std::complex<float> **b, std::int64_t *ldb,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                            alpha, a, lda, b, ldb, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsm_batch(
+        selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b,
+        ldb, group_count, group_size, dependencies);
+    trsm_batch_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event trsm_batch(backend_selector<backend::syclblas> selector, side *left_right,
+                       uplo *upper_lower, transpose *trans, diag *unit_diag, std::int64_t *m,
+                       std::int64_t *n, std::complex<double> *alpha, const std::complex<double> **a,
+                       std::int64_t *lda, std::complex<double> **b, std::int64_t *ldb,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    trsm_batch_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                            alpha, a, lda, b, ldb, group_count, group_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsm_batch(
+        selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha, a, lda, b,
+        ldb, group_count, group_size, dependencies);
+    trsm_batch_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n,
+                             alpha, a, lda, b, ldb, group_count, group_size, dependencies);
+    return done;
+}
+
+sycl::event dotu(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
+                 std::int64_t incy, std::complex<float> *result,
+                 const std::vector<sycl::event> &dependencies) {
+    dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy,
+                                                         result, dependencies);
+    dotu_postcondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    return done;
+}
+
+sycl::event dotu(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
+                 std::int64_t incy, std::complex<double> *result,
+                 const std::vector<sycl::event> &dependencies) {
+    dotu_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dotu(selector.get_queue(), n, x, incx, y, incy,
+                                                         result, dependencies);
+    dotu_postcondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    return done;
+}
+
+sycl::event hemm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
+                 std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::hemm(selector.get_queue(), left_right,
+                                                         upper_lower, m, n, alpha, a, lda, b, ldb,
+                                                         beta, c, ldc, dependencies);
+    hemm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc, dependencies);
+    return done;
+}
+
+sycl::event hemm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
+                 std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    hemm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::hemm(selector.get_queue(), left_right,
+                                                         upper_lower, m, n, alpha, a, lda, b, ldb,
+                                                         beta, c, ldc, dependencies);
+    hemm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc, dependencies);
+    return done;
+}
+
+sycl::event hpr2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
+                 const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
+                 const std::vector<sycl::event> &dependencies) {
+    hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::hpr2(selector.get_queue(), upper_lower, n,
+                                                         alpha, x, incx, y, incy, a, dependencies);
+    hpr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
+                       dependencies);
+    return done;
+}
+
+sycl::event hpr2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
+                 const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
+                 const std::vector<sycl::event> &dependencies) {
+    hpr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::hpr2(selector.get_queue(), upper_lower, n,
+                                                         alpha, x, incx, y, incy, a, dependencies);
+    hpr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
+                       dependencies);
+    return done;
+}
+
+sycl::event gbmv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                 std::int64_t n, std::int64_t kl, std::int64_t ku, float alpha, const float *a,
+                 std::int64_t lda, const float *x, std::int64_t incx, float beta, float *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                      incy, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::gbmv(selector.get_queue(), trans, m, n, kl, ku, alpha,
+                                                 a, lda, x, incx, beta, y, incy, dependencies);
+    gbmv_postcondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                       incy, dependencies);
+    return done;
+}
+
+sycl::event gbmv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                 std::int64_t n, std::int64_t kl, std::int64_t ku, double alpha, const double *a,
+                 std::int64_t lda, const double *x, std::int64_t incx, double beta, double *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                      incy, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::gbmv(selector.get_queue(), trans, m, n, kl, ku, alpha,
+                                                 a, lda, x, incx, beta, y, incy, dependencies);
+    gbmv_postcondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                       incy, dependencies);
+    return done;
+}
+
+sycl::event gbmv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                 std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
+                 const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
+                 std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                      incy, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::gbmv(selector.get_queue(), trans, m, n, kl, ku, alpha,
+                                                 a, lda, x, incx, beta, y, incy, dependencies);
+    gbmv_postcondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                       incy, dependencies);
+    return done;
+}
+
+sycl::event gbmv(backend_selector<backend::syclblas> selector, transpose trans, std::int64_t m,
+                 std::int64_t n, std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
+                 const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
+                 std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    gbmv_precondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                      incy, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::gbmv(selector.get_queue(), trans, m, n, kl, ku, alpha,
+                                                 a, lda, x, incx, beta, y, incy, dependencies);
+    gbmv_postcondition(selector.get_queue(), trans, m, n, kl, ku, alpha, a, lda, x, incx, beta, y,
+                       incy, dependencies);
+    return done;
+}
+
+sycl::event tbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, std::int64_t k, const float *a, std::int64_t lda,
+                 float *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tbmv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
+    tbmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, std::int64_t k, const double *a, std::int64_t lda,
+                 double *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tbmv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
+    tbmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
+                 std::int64_t lda, std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tbmv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
+    tbmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
+                 std::int64_t lda, std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    tbmv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tbmv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
+    tbmv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event symm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
+                 const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::symm(selector.get_queue(), left_right,
+                                                         upper_lower, m, n, alpha, a, lda, b, ldb,
+                                                         beta, c, ldc, dependencies);
+    symm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc, dependencies);
+    return done;
+}
+
+sycl::event symm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
+                 const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::symm(selector.get_queue(), left_right,
+                                                         upper_lower, m, n, alpha, a, lda, b, ldb,
+                                                         beta, c, ldc, dependencies);
+    symm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc, dependencies);
+    return done;
+}
+
+sycl::event symm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
+                 std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::symm(selector.get_queue(), left_right,
+                                                         upper_lower, m, n, alpha, a, lda, b, ldb,
+                                                         beta, c, ldc, dependencies);
+    symm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc, dependencies);
+    return done;
+}
+
+sycl::event symm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
+                 std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    symm_precondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                      beta, c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::symm(selector.get_queue(), left_right,
+                                                         upper_lower, m, n, alpha, a, lda, b, ldb,
+                                                         beta, c, ldc, dependencies);
+    symm_postcondition(selector.get_queue(), left_right, upper_lower, m, n, alpha, a, lda, b, ldb,
+                       beta, c, ldc, dependencies);
+    return done;
+}
+
+sycl::event dotc(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
+                 std::int64_t incy, std::complex<float> *result,
+                 const std::vector<sycl::event> &dependencies) {
+    dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy,
+                                                         result, dependencies);
+    dotc_postcondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    return done;
+}
+
+sycl::event dotc(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
+                 std::int64_t incy, std::complex<double> *result,
+                 const std::vector<sycl::event> &dependencies) {
+    dotc_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dotc(selector.get_queue(), n, x, incx, y, incy,
+                                                         result, dependencies);
+    dotc_postcondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    return done;
+}
+
+sycl::event syr(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                float alpha, const float *x, std::int64_t incx, float *a, std::int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
+    syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha,
+                                                        x, incx, a, lda, dependencies);
+    syr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
+    return done;
+}
+
+sycl::event syr(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                double alpha, const double *x, std::int64_t incx, double *a, std::int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
+    syr_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::syr(selector.get_queue(), upper_lower, n, alpha,
+                                                        x, incx, a, lda, dependencies);
+    syr_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, a, lda, dependencies);
+    return done;
+}
+
+sycl::event trmm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
+                 const float *a, std::int64_t lda, float *b, std::int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
+    trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trmm(selector.get_queue(), left_right,
+                                                         upper_lower, trans, unit_diag, m, n, alpha,
+                                                         a, lda, b, ldb, dependencies);
+    trmm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb, dependencies);
+    return done;
+}
+
+sycl::event trmm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
+                 const double *a, std::int64_t lda, double *b, std::int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
+    trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trmm(selector.get_queue(), left_right,
+                                                         upper_lower, trans, unit_diag, m, n, alpha,
+                                                         a, lda, b, ldb, dependencies);
+    trmm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb, dependencies);
+    return done;
+}
+
+sycl::event trmm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
+                 std::complex<float> *b, std::int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
+    trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trmm(selector.get_queue(), left_right,
+                                                         upper_lower, trans, unit_diag, m, n, alpha,
+                                                         a, lda, b, ldb, dependencies);
+    trmm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb, dependencies);
+    return done;
+}
+
+sycl::event trmm(backend_selector<backend::syclblas> selector, side left_right, uplo upper_lower,
+                 transpose trans, diag unit_diag, std::int64_t m, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
+                 std::complex<double> *b, std::int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
+    trmm_precondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                      a, lda, b, ldb, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trmm(selector.get_queue(), left_right,
+                                                         upper_lower, trans, unit_diag, m, n, alpha,
+                                                         a, lda, b, ldb, dependencies);
+    trmm_postcondition(selector.get_queue(), left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                       a, lda, b, ldb, dependencies);
+    return done;
+}
+
+sycl::event rotmg(backend_selector<backend::syclblas> selector, float *d1, float *d2, float *x1,
+                  float y1, float *param, const std::vector<sycl::event> &dependencies) {
+    rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1,
+                                                          param, dependencies);
+    rotmg_postcondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
+    return done;
+}
+
+sycl::event rotmg(backend_selector<backend::syclblas> selector, double *d1, double *d2, double *x1,
+                  double y1, double *param, const std::vector<sycl::event> &dependencies) {
+    rotmg_precondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::rotmg(selector.get_queue(), d1, d2, x1, y1,
+                                                          param, dependencies);
+    rotmg_postcondition(selector.get_queue(), d1, d2, x1, y1, param, dependencies);
+    return done;
+}
+
+sycl::event tpsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const float *a, float *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
+                                                         unit_diag, n, a, x, incx, dependencies);
+    tpsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tpsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const double *a, double *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
+                                                         unit_diag, n, a, x, incx, dependencies);
+    tpsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tpsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const std::complex<float> *a,
+                 std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
+                                                         unit_diag, n, a, x, incx, dependencies);
+    tpsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tpsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const std::complex<double> *a,
+                 std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    tpsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tpsv(selector.get_queue(), upper_lower, trans,
+                                                         unit_diag, n, a, x, incx, dependencies);
+    tpsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event trsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const float *a, std::int64_t lda, float *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
+    trsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event trsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const double *a, std::int64_t lda, double *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
+    trsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event trsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const std::complex<float> *a, std::int64_t lda,
+                 std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
+    trsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event trsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, const std::complex<double> *a, std::int64_t lda,
+                 std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    trsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::trsv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx, dependencies);
+    trsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event copy(backend_selector<backend::syclblas> selector, std::int64_t n, const float *x,
+                 std::int64_t incx, float *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
+                                                         dependencies);
+    copy_postcondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    return done;
+}
+
+sycl::event copy(backend_selector<backend::syclblas> selector, std::int64_t n, const double *x,
+                 std::int64_t incx, double *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
+                                                         dependencies);
+    copy_postcondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    return done;
+}
+
+sycl::event copy(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
+                                                         dependencies);
+    copy_postcondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    return done;
+}
+
+sycl::event copy(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    copy_precondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::copy(selector.get_queue(), n, x, incx, y, incy,
+                                                         dependencies);
+    copy_postcondition(selector.get_queue(), n, x, incx, y, incy, dependencies);
+    return done;
+}
+
+sycl::event copy_batch(backend_selector<backend::syclblas> selector, std::int64_t *n,
+                       const float **x, std::int64_t *incx, float **y, std::int64_t *incy,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
+                            dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::copy_batch(
+        selector.get_queue(), n, x, incx, y, incy, group_count, group_size, dependencies);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
+                             dependencies);
+    return done;
+}
+
+sycl::event copy_batch(backend_selector<backend::syclblas> selector, std::int64_t *n,
+                       const double **x, std::int64_t *incx, double **y, std::int64_t *incy,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
+                            dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::copy_batch(
+        selector.get_queue(), n, x, incx, y, incy, group_count, group_size, dependencies);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
+                             dependencies);
+    return done;
+}
+
+sycl::event copy_batch(backend_selector<backend::syclblas> selector, std::int64_t *n,
+                       const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y,
+                       std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
+                            dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::copy_batch(
+        selector.get_queue(), n, x, incx, y, incy, group_count, group_size, dependencies);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
+                             dependencies);
+    return done;
+}
+
+sycl::event copy_batch(backend_selector<backend::syclblas> selector, std::int64_t *n,
+                       const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
+                       std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
+                            dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::copy_batch(
+        selector.get_queue(), n, x, incx, y, incy, group_count, group_size, dependencies);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, y, incy, group_count, group_size,
+                             dependencies);
+    return done;
+}
+
+sycl::event copy_batch(backend_selector<backend::syclblas> selector, std::int64_t n, const float *x,
+                       std::int64_t incx, std::int64_t stridex, float *y, std::int64_t incy,
+                       std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
+                            dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::copy_batch(
+        selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                             batch_size, dependencies);
+    return done;
+}
+
+sycl::event copy_batch(backend_selector<backend::syclblas> selector, std::int64_t n,
+                       const double *x, std::int64_t incx, std::int64_t stridex, double *y,
+                       std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
+                            dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::copy_batch(
+        selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                             batch_size, dependencies);
+    return done;
+}
+
+sycl::event copy_batch(backend_selector<backend::syclblas> selector, std::int64_t n,
+                       const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
+                       std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
+                            dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::copy_batch(
+        selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                             batch_size, dependencies);
+    return done;
+}
+
+sycl::event copy_batch(backend_selector<backend::syclblas> selector, std::int64_t n,
+                       const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
+                       std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    copy_batch_precondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size,
+                            dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::copy_batch(
+        selector.get_queue(), n, x, incx, stridex, y, incy, stridey, batch_size, dependencies);
+    copy_batch_postcondition(selector.get_queue(), n, x, incx, stridex, y, incy, stridey,
+                             batch_size, dependencies);
+    return done;
+}
+
+sycl::event hemv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
+                 const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::hemv(
+        selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
+    hemv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
+                       dependencies);
+    return done;
+}
+
+sycl::event hemv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
+                 const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    hemv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::hemv(
+        selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
+    hemv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
+                       dependencies);
+    return done;
+}
+
+sycl::event gemmt(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose transa,
+                  transpose transb, std::int64_t n, std::int64_t k, float alpha, const float *a,
+                  std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
+                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                       ldb, beta, c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
+                                                          transb, n, k, alpha, a, lda, b, ldb, beta,
+                                                          c, ldc, dependencies);
+    gemmt_postcondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                        ldb, beta, c, ldc, dependencies);
+    return done;
+}
+
+sycl::event gemmt(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose transa,
+                  transpose transb, std::int64_t n, std::int64_t k, double alpha, const double *a,
+                  std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
+                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                       ldb, beta, c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
+                                                          transb, n, k, alpha, a, lda, b, ldb, beta,
+                                                          c, ldc, dependencies);
+    gemmt_postcondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                        ldb, beta, c, ldc, dependencies);
+    return done;
+}
+
+sycl::event gemmt(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose transa,
+                  transpose transb, std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                  const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
+                  std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
+                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                       ldb, beta, c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
+                                                          transb, n, k, alpha, a, lda, b, ldb, beta,
+                                                          c, ldc, dependencies);
+    gemmt_postcondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                        ldb, beta, c, ldc, dependencies);
+    return done;
+}
+
+sycl::event gemmt(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose transa,
+                  transpose transb, std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                  const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
+                  std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
+                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    gemmt_precondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                       ldb, beta, c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::gemmt(selector.get_queue(), upper_lower, transa,
+                                                          transb, n, k, alpha, a, lda, b, ldb, beta,
+                                                          c, ldc, dependencies);
+    gemmt_postcondition(selector.get_queue(), upper_lower, transa, transb, n, k, alpha, a, lda, b,
+                        ldb, beta, c, ldc, dependencies);
+    return done;
+}
+
+sycl::event sbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 std::int64_t k, float alpha, const float *a, std::int64_t lda, const float *x,
+                 std::int64_t incx, float beta, float *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                      incy, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::sbmv(selector.get_queue(), upper_lower, n, k, alpha, a,
+                                                 lda, x, incx, beta, y, incy, dependencies);
+    sbmv_postcondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                       incy, dependencies);
+    return done;
+}
+
+sycl::event sbmv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 std::int64_t k, double alpha, const double *a, std::int64_t lda, const double *x,
+                 std::int64_t incx, double beta, double *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    sbmv_precondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                      incy, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::sbmv(selector.get_queue(), upper_lower, n, k, alpha, a,
+                                                 lda, x, incx, beta, y, incy, dependencies);
+    sbmv_postcondition(selector.get_queue(), upper_lower, n, k, alpha, a, lda, x, incx, beta, y,
+                       incy, dependencies);
+    return done;
+}
+
+sycl::event asum(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 const std::complex<float> *x, std::int64_t incx, float *result,
+                 const std::vector<sycl::event> &dependencies) {
+    asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::asum(selector.get_queue(), n, x, incx, result,
+                                                         dependencies);
+    asum_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event asum(backend_selector<backend::syclblas> selector, std::int64_t n,
+                 const std::complex<double> *x, std::int64_t incx, double *result,
+                 const std::vector<sycl::event> &dependencies) {
+    asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::asum(selector.get_queue(), n, x, incx, result,
+                                                         dependencies);
+    asum_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event asum(backend_selector<backend::syclblas> selector, std::int64_t n, const float *x,
+                 std::int64_t incx, float *result, const std::vector<sycl::event> &dependencies) {
+    asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::asum(selector.get_queue(), n, x, incx, result,
+                                                         dependencies);
+    asum_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event asum(backend_selector<backend::syclblas> selector, std::int64_t n, const double *x,
+                 std::int64_t incx, double *result, const std::vector<sycl::event> &dependencies) {
+    asum_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::asum(selector.get_queue(), n, x, incx, result,
+                                                         dependencies);
+    asum_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event tbsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, std::int64_t k, const float *a, std::int64_t lda,
+                 float *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tbsv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
+    tbsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tbsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, std::int64_t k, const double *a, std::int64_t lda,
+                 double *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tbsv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
+    tbsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tbsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<float> *a,
+                 std::int64_t lda, std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tbsv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
+    tbsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event tbsv(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                 diag unit_diag, std::int64_t n, std::int64_t k, const std::complex<double> *a,
+                 std::int64_t lda, std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    tbsv_precondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::tbsv(
+        selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx, dependencies);
+    tbsv_postcondition(selector.get_queue(), upper_lower, trans, unit_diag, n, k, a, lda, x, incx,
+                       dependencies);
+    return done;
+}
+
+sycl::event spr2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 float alpha, const float *x, std::int64_t incx, const float *y, std::int64_t incy,
+                 float *a, const std::vector<sycl::event> &dependencies) {
+    spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::spr2(selector.get_queue(), upper_lower, n,
+                                                         alpha, x, incx, y, incy, a, dependencies);
+    spr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
+                       dependencies);
+    return done;
+}
+
+sycl::event spr2(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 double alpha, const double *x, std::int64_t incx, const double *y,
+                 std::int64_t incy, double *a, const std::vector<sycl::event> &dependencies) {
+    spr2_precondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::spr2(selector.get_queue(), upper_lower, n,
+                                                         alpha, x, incx, y, incy, a, dependencies);
+    spr2_postcondition(selector.get_queue(), upper_lower, n, alpha, x, incx, y, incy, a,
+                       dependencies);
+    return done;
+}
+
+sycl::event iamax(backend_selector<backend::syclblas> selector, std::int64_t n, const float *x,
+                  std::int64_t incx, std::int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
+    iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
+                                                          dependencies);
+    iamax_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event iamax(backend_selector<backend::syclblas> selector, std::int64_t n, const double *x,
+                  std::int64_t incx, std::int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
+    iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
+                                                          dependencies);
+    iamax_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event iamax(backend_selector<backend::syclblas> selector, std::int64_t n,
+                  const std::complex<float> *x, std::int64_t incx, std::int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
+    iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
+                                                          dependencies);
+    iamax_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event iamax(backend_selector<backend::syclblas> selector, std::int64_t n,
+                  const std::complex<double> *x, std::int64_t incx, std::int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
+    iamax_precondition(selector.get_queue(), n, x, incx, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
+                                                          dependencies);
+    iamax_postcondition(selector.get_queue(), n, x, incx, result, dependencies);
+    return done;
+}
+
+sycl::event rotm(backend_selector<backend::syclblas> selector, std::int64_t n, float *x,
+                 std::int64_t incx, float *y, std::int64_t incy, float *param,
+                 const std::vector<sycl::event> &dependencies) {
+    rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
+                                                         param, dependencies);
+    rotm_postcondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
+    return done;
+}
+
+sycl::event rotm(backend_selector<backend::syclblas> selector, std::int64_t n, double *x,
+                 std::int64_t incx, double *y, std::int64_t incy, double *param,
+                 const std::vector<sycl::event> &dependencies) {
+    rotm_precondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::rotm(selector.get_queue(), n, x, incx, y, incy,
+                                                         param, dependencies);
+    rotm_postcondition(selector.get_queue(), n, x, incx, y, incy, param, dependencies);
+    return done;
+}
+
+sycl::event rotg(backend_selector<backend::syclblas> selector, float *a, float *b, float *c,
+                 float *s, const std::vector<sycl::event> &dependencies) {
+    rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
+    rotg_postcondition(selector.get_queue(), a, b, c, s, dependencies);
+    return done;
+}
+
+sycl::event rotg(backend_selector<backend::syclblas> selector, double *a, double *b, double *c,
+                 double *s, const std::vector<sycl::event> &dependencies) {
+    rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
+    rotg_postcondition(selector.get_queue(), a, b, c, s, dependencies);
+    return done;
+}
+
+sycl::event rotg(backend_selector<backend::syclblas> selector, std::complex<float> *a,
+                 std::complex<float> *b, float *c, std::complex<float> *s,
+                 const std::vector<sycl::event> &dependencies) {
+    rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
+    rotg_postcondition(selector.get_queue(), a, b, c, s, dependencies);
+    return done;
+}
+
+sycl::event rotg(backend_selector<backend::syclblas> selector, std::complex<double> *a,
+                 std::complex<double> *b, double *c, std::complex<double> *s,
+                 const std::vector<sycl::event> &dependencies) {
+    rotg_precondition(selector.get_queue(), a, b, c, s, dependencies);
+    auto done =
+        oneapi::mkl::blas::syclblas::MAJOR::rotg(selector.get_queue(), a, b, c, s, dependencies);
+    rotg_postcondition(selector.get_queue(), a, b, c, s, dependencies);
+    return done;
+}
+
+sycl::event sdsdot(backend_selector<backend::syclblas> selector, std::int64_t n, float sb,
+                   const float *x, std::int64_t incx, const float *y, std::int64_t incy,
+                   float *result, const std::vector<sycl::event> &dependencies) {
+    sdsdot_precondition(selector.get_queue(), n, sb, x, incx, y, incy, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::sdsdot(selector.get_queue(), n, sb, x, incx, y,
+                                                           incy, result, dependencies);
+    sdsdot_postcondition(selector.get_queue(), n, sb, x, incx, y, incy, result, dependencies);
+    return done;
+}
+
+sycl::event her2k(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                  std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                  const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
+                  std::int64_t ldb, float beta, std::complex<float> *c, std::int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
+    her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::her2k(selector.get_queue(), upper_lower, trans,
+                                                          n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+                                                          dependencies);
+    her2k_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                        c, ldc, dependencies);
+    return done;
+}
+
+sycl::event her2k(backend_selector<backend::syclblas> selector, uplo upper_lower, transpose trans,
+                  std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                  const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
+                  std::int64_t ldb, double beta, std::complex<double> *c, std::int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
+    her2k_precondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                       c, ldc, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::her2k(selector.get_queue(), upper_lower, trans,
+                                                          n, k, alpha, a, lda, b, ldb, beta, c, ldc,
+                                                          dependencies);
+    her2k_postcondition(selector.get_queue(), upper_lower, trans, n, k, alpha, a, lda, b, ldb, beta,
+                        c, ldc, dependencies);
+    return done;
+}
+
+sycl::event dot(backend_selector<backend::syclblas> selector, std::int64_t n, const float *x,
+                std::int64_t incx, const float *y, std::int64_t incy, float *result,
+                const std::vector<sycl::event> &dependencies) {
+    dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
+                                                        result, dependencies);
+    dot_postcondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    return done;
+}
+
+sycl::event dot(backend_selector<backend::syclblas> selector, std::int64_t n, const double *x,
+                std::int64_t incx, const double *y, std::int64_t incy, double *result,
+                const std::vector<sycl::event> &dependencies) {
+    dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
+                                                        result, dependencies);
+    dot_postcondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    return done;
+}
+
+sycl::event dot(backend_selector<backend::syclblas> selector, std::int64_t n, const float *x,
+                std::int64_t incx, const float *y, std::int64_t incy, double *result,
+                const std::vector<sycl::event> &dependencies) {
+    dot_precondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::dot(selector.get_queue(), n, x, incx, y, incy,
+                                                        result, dependencies);
+    dot_postcondition(selector.get_queue(), n, x, incx, y, incy, result, dependencies);
+    return done;
+}
+
+sycl::event symv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
+                 float beta, float *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::symv(
+        selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
+    symv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
+                       dependencies);
+    return done;
+}
+
+sycl::event symv(backend_selector<backend::syclblas> selector, uplo upper_lower, std::int64_t n,
+                 double alpha, const double *a, std::int64_t lda, const double *x,
+                 std::int64_t incx, double beta, double *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    symv_precondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
+                      dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::symv(
+        selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy, dependencies);
+    symv_postcondition(selector.get_queue(), upper_lower, n, alpha, a, lda, x, incx, beta, y, incy,
+                       dependencies);
+    return done;
+}
+
+sycl::event omatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans,
+                           std::int64_t m, std::int64_t n, float alpha, const float *a,
+                           std::int64_t lda, std::int64_t stride_a, float *b, std::int64_t ldb,
+                           std::int64_t stride_b, std::int64_t batch_size,
+                           const std::vector<sycl::event> &dependencies) {
+    omatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                stride_b, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::omatcopy_batch(
+        selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
+        dependencies);
+    omatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                 stride_b, batch_size, dependencies);
+    return done;
+}
+
+sycl::event omatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans,
+                           std::int64_t m, std::int64_t n, double alpha, const double *a,
+                           std::int64_t lda, std::int64_t stride_a, double *b, std::int64_t ldb,
+                           std::int64_t stride_b, std::int64_t batch_size,
+                           const std::vector<sycl::event> &dependencies) {
+    omatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                stride_b, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::omatcopy_batch(
+        selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
+        dependencies);
+    omatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                 stride_b, batch_size, dependencies);
+    return done;
+}
+
+sycl::event omatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans,
+                           std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                           const std::complex<float> *a, std::int64_t lda, std::int64_t stride_a,
+                           std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
+                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    omatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                stride_b, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::omatcopy_batch(
+        selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
+        dependencies);
+    omatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                 stride_b, batch_size, dependencies);
+    return done;
+}
+
+sycl::event omatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans,
+                           std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                           const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
+                           std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
+                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    omatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                stride_b, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::omatcopy_batch(
+        selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb, stride_b, batch_size,
+        dependencies);
+    omatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, a, lda, stride_a, b, ldb,
+                                 stride_b, batch_size, dependencies);
+    return done;
+}
+
+sycl::event imatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans,
+                           std::int64_t m, std::int64_t n, float alpha, float *ab, std::int64_t lda,
+                           std::int64_t ldb, std::int64_t stride, std::int64_t batch_size,
+                           const std::vector<sycl::event> &dependencies) {
+    imatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::imatcopy_batch(
+        selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride, batch_size, dependencies);
+    imatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                 batch_size, dependencies);
+    return done;
+}
+
+sycl::event imatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans,
+                           std::int64_t m, std::int64_t n, double alpha, double *ab,
+                           std::int64_t lda, std::int64_t ldb, std::int64_t stride,
+                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    imatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::imatcopy_batch(
+        selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride, batch_size, dependencies);
+    imatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                 batch_size, dependencies);
+    return done;
+}
+
+sycl::event imatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans,
+                           std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                           std::complex<float> *ab, std::int64_t lda, std::int64_t ldb,
+                           std::int64_t stride, std::int64_t batch_size,
+                           const std::vector<sycl::event> &dependencies) {
+    imatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::imatcopy_batch(
+        selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride, batch_size, dependencies);
+    imatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                 batch_size, dependencies);
+    return done;
+}
+
+sycl::event imatcopy_batch(backend_selector<backend::syclblas> selector, transpose trans,
+                           std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                           std::complex<double> *ab, std::int64_t lda, std::int64_t ldb,
+                           std::int64_t stride, std::int64_t batch_size,
+                           const std::vector<sycl::event> &dependencies) {
+    imatcopy_batch_precondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::imatcopy_batch(
+        selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride, batch_size, dependencies);
+    imatcopy_batch_postcondition(selector.get_queue(), trans, m, n, alpha, ab, lda, ldb, stride,
+                                 batch_size, dependencies);
+    return done;
+}
+
+sycl::event omatadd_batch(backend_selector<backend::syclblas> selector, transpose transa,
+                          transpose transb, std::int64_t m, std::int64_t n, float alpha,
+                          const float *a, std::int64_t lda, std::int64_t stride_a, float beta,
+                          const float *b, std::int64_t ldb, std::int64_t stride_b, float *c,
+                          std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                          const std::vector<sycl::event> &dependencies) {
+    omatadd_batch_precondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                               beta, b, ldb, stride_b, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::omatadd_batch(
+        selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a, beta, b, ldb, stride_b,
+        c, ldc, stride_c, batch_size, dependencies);
+    omatadd_batch_postcondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                                beta, b, ldb, stride_b, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}
+
+sycl::event omatadd_batch(backend_selector<backend::syclblas> selector, transpose transa,
+                          transpose transb, std::int64_t m, std::int64_t n, double alpha,
+                          const double *a, std::int64_t lda, std::int64_t stride_a, double beta,
+                          const double *b, std::int64_t ldb, std::int64_t stride_b, double *c,
+                          std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                          const std::vector<sycl::event> &dependencies) {
+    omatadd_batch_precondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                               beta, b, ldb, stride_b, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::omatadd_batch(
+        selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a, beta, b, ldb, stride_b,
+        c, ldc, stride_c, batch_size, dependencies);
+    omatadd_batch_postcondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                                beta, b, ldb, stride_b, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}
+
+sycl::event omatadd_batch(backend_selector<backend::syclblas> selector, transpose transa,
+                          transpose transb, std::int64_t m, std::int64_t n,
+                          std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
+                          std::int64_t stride_a, std::complex<float> beta,
+                          const std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
+                          std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
+                          std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    omatadd_batch_precondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                               beta, b, ldb, stride_b, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::omatadd_batch(
+        selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a, beta, b, ldb, stride_b,
+        c, ldc, stride_c, batch_size, dependencies);
+    omatadd_batch_postcondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                                beta, b, ldb, stride_b, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}
+
+sycl::event omatadd_batch(backend_selector<backend::syclblas> selector, transpose transa,
+                          transpose transb, std::int64_t m, std::int64_t n,
+                          std::complex<double> alpha, const std::complex<double> *a,
+                          std::int64_t lda, std::int64_t stride_a, std::complex<double> beta,
+                          const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
+                          std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
+                          std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    omatadd_batch_precondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                               beta, b, ldb, stride_b, c, ldc, stride_c, batch_size, dependencies);
+    auto done = oneapi::mkl::blas::syclblas::MAJOR::omatadd_batch(
+        selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a, beta, b, ldb, stride_b,
+        c, ldc, stride_c, batch_size, dependencies);
+    omatadd_batch_postcondition(selector.get_queue(), transa, transb, m, n, alpha, a, lda, stride_a,
+                                beta, b, ldb, stride_b, c, ldc, stride_c, batch_size, dependencies);
+    return done;
+}

--- a/include/oneapi/mkl/blas/detail/syclblas/onemkl_blas_syclblas.hpp
+++ b/include/oneapi/mkl/blas/detail/syclblas/onemkl_blas_syclblas.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2020-2021 Intel Corporation
+* Copyright Codeplay Software
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,59 +17,43 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
-#ifndef _ONEMKL_BLAS_HPP_
-#define _ONEMKL_BLAS_HPP_
+#ifndef _ONEMKL_BLAS_SYCLBLAS_HPP_
+#define _ONEMKL_BLAS_SYCLBLAS_HPP_
 
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
 #else
 #include <CL/sycl.hpp>
 #endif
-#include <complex>
-#include <cstdint>
 
-#include "oneapi/mkl/detail/config.hpp"
 #include "oneapi/mkl/types.hpp"
 
-#include "oneapi/mkl/detail/get_device_id.hpp"
-
-#include "oneapi/mkl/blas/predicates.hpp"
-
-#include "oneapi/mkl/blas/detail/blas_loader.hpp"
-#ifdef ENABLE_CUBLAS_BACKEND
-#include "oneapi/mkl/blas/detail/cublas/blas_ct.hpp"
-#endif
-#ifdef ENABLE_ROCBLAS_BACKEND
-#include "oneapi/mkl/blas/detail/rocblas/blas_ct.hpp"
-#endif
-#ifdef ENABLE_MKLCPU_BACKEND
-#include "oneapi/mkl/blas/detail/mklcpu/blas_ct.hpp"
-#endif
-#ifdef ENABLE_MKLGPU_BACKEND
-#include "oneapi/mkl/blas/detail/mklgpu/blas_ct.hpp"
-#endif
-#ifdef ENABLE_NETLIB_BACKEND
-#include "oneapi/mkl/blas/detail/netlib/blas_ct.hpp"
-#endif
-#ifdef ENABLE_SYCLBLAS_BACKEND
-#include "oneapi/mkl/blas/detail/syclblas/blas_ct.hpp"
-#endif
+#include "oneapi/mkl/detail/export.hpp"
 
 namespace oneapi {
 namespace mkl {
+
+using oneapi::mkl::transpose;
+using oneapi::mkl::uplo;
+using oneapi::mkl::side;
+using oneapi::mkl::diag;
+using oneapi::mkl::offset;
+
 namespace blas {
+namespace syclblas {
 namespace column_major {
 
-#include "blas.hxx"
+#include "oneapi/mkl/blas/detail/onemkl_blas_backends.hxx"
 
 } //namespace column_major
 namespace row_major {
 
-#include "blas.hxx"
+#include "oneapi/mkl/blas/detail/onemkl_blas_backends.hxx"
 
 } //namespace row_major
-} //namespace blas
-} //namespace mkl
-} //namespace oneapi
+} // namespace syclblas
+} // namespace blas
+} // namespace mkl
+} // namespace oneapi
 
-#endif //_ONEMKL_BLAS_LOADER_HPP_
+#endif // _ONEMKL_BLAS_SYCLBLAS_HPP_

--- a/include/oneapi/mkl/detail/backends.hpp
+++ b/include/oneapi/mkl/detail/backends.hpp
@@ -35,17 +35,18 @@ enum class backend {
     netlib,
     rocblas,
     rocrand,
+    syclblas,
     unsupported
 };
 
 typedef std::map<backend, std::string> backendmap;
 
 static backendmap backend_map = {
-    { backend::mklcpu, "mklcpu" },          { backend::mklgpu, "mklgpu" },
-    { backend::cublas, "cublas" },          { backend::cusolver, "cusolver" },
-    { backend::curand, "curand" },          { backend::netlib, "netlib" },
-    { backend::rocblas, "rocblas" },        { backend::rocrand, "rocrand" },
-    { backend::unsupported, "unsupported" }
+    { backend::mklcpu, "mklcpu" },     { backend::mklgpu, "mklgpu" },
+    { backend::cublas, "cublas" },     { backend::cusolver, "cusolver" },
+    { backend::curand, "curand" },     { backend::netlib, "netlib" },
+    { backend::rocblas, "rocblas" },   { backend::rocrand, "rocrand" },
+    { backend::syclblas, "syclblas" }, { backend::unsupported, "unsupported" }
 };
 
 } //namespace mkl

--- a/include/oneapi/mkl/detail/backends_table.hpp
+++ b/include/oneapi/mkl/detail/backends_table.hpp
@@ -57,7 +57,10 @@ static std::map<domain, std::map<device, std::vector<const char*>>> libraries = 
         { device::intelgpu,
           {
 #ifdef ENABLE_MKLGPU_BACKEND
-              LIB_NAME("blas_mklgpu")
+              LIB_NAME("blas_mklgpu"),
+#endif
+#ifdef ENABLE_SYCLBLAS_BACKEND
+              LIB_NAME("blas_syclblas")
 #endif
           } },
         { device::amdgpu,

--- a/src/blas/backends/CMakeLists.txt
+++ b/src/blas/backends/CMakeLists.txt
@@ -1,6 +1,5 @@
 #===============================================================================
 # Copyright 2020-2021 Intel Corporation
-# Copyright Codeplay Software
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/blas/backends/CMakeLists.txt
+++ b/src/blas/backends/CMakeLists.txt
@@ -1,5 +1,6 @@
 #===============================================================================
 # Copyright 2020-2021 Intel Corporation
+# Copyright Codeplay Software
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,4 +36,8 @@ endif()
 
 if(ENABLE_ROCBLAS_BACKEND AND UNIX)
   add_subdirectory(rocblas)
+endif()
+
+if(ENABLE_SYCLBLAS_BACKEND)
+  add_subdirectory(syclblas)
 endif()

--- a/src/blas/backends/syclblas/CMakeLists.txt
+++ b/src/blas/backends/syclblas/CMakeLists.txt
@@ -1,0 +1,71 @@
+#==========================================================================
+#  Copyright (C) Codeplay Software Limited
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  For your convenience, a copy of the License has been included in this
+#  repository.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#=========================================================================
+
+set(LIB_NAME onemkl_blas_syclblas)
+set(LIB_OBJ ${LIB_NAME}_obj)
+
+find_package(SyclBLAS REQUIRED)
+
+set(SOURCES 
+  syclblas_level1.cpp syclblas_level2.cpp syclblas_level3.cpp syclblas_batch.cpp 
+  $<$<BOOL:${BUILD_SHARED_LIBS}>: syclblas_wrappers.cpp>)
+add_library(${LIB_NAME})
+add_library(${LIB_OBJ} OBJECT ${SOURCES})
+
+if (USE_ADD_SYCL_TO_TARGET_INTEGRATION)
+  add_sycl_to_target(TARGET ${LIB_OBJ} SOURCES ${SOURCES})
+endif()
+
+target_include_directories(${LIB_OBJ}
+  PRIVATE ${PROJECT_SOURCE_DIR}/include
+          ${PROJECT_SOURCE_DIR}/src/include
+          ${PROJECT_SOURCE_DIR}/src
+          ${CMAKE_BINARY_DIR}/bin
+          ${SyclBLAS_INCLUDE}
+)
+
+target_compile_options(${LIB_OBJ} PRIVATE ${ONEMKL_BUILD_COPT})
+target_link_libraries(${LIB_OBJ} PUBLIC ONEMKL::SYCL::SYCL SyclBLAS::SyclBLAS)
+
+set_target_properties(${LIB_OBJ} PROPERTIES
+  POSITION_INDEPENDENT_CODE ON)
+
+target_link_libraries(${LIB_NAME} PUBLIC ${LIB_OBJ})
+
+if(BUILD_SHARED_LIBS)
+  set_target_properties(${LIB_NAME} PROPERTIES
+    INTERFACE_LINK_LIBRARIES ONEMKL::SYCL::SYCL
+  )
+endif()
+
+# Add major version to the library
+set_target_properties(${LIB_NAME} PROPERTIES
+  SOVERSION ${PROJECT_VERSION_MAJOR}
+)
+
+# Add dependencies rpath to the library
+list(APPEND CMAKE_BUILD_RPATH $<TARGET_FILE_DIR:${LIB_NAME}>)
+
+# Add the library to install package
+install(TARGETS ${LIB_OBJ} EXPORT oneMKLTargets)
+install(TARGETS ${LIB_NAME} EXPORT oneMKLTargets
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)

--- a/src/blas/backends/syclblas/syclblas_batch.cpp
+++ b/src/blas/backends/syclblas/syclblas_batch.cpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+* Copyright Codeplay Software
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
+#include "syclblas_common.hpp"
+#include "oneapi/mkl/exceptions.hpp"
+#include "oneapi/mkl/blas/detail/syclblas/onemkl_blas_syclblas.hpp"
+
+namespace oneapi {
+namespace mkl {
+namespace blas {
+namespace syclblas {
+namespace column_major {
+
+#define COLUMN_MAJOR
+constexpr bool is_column_major() {
+    return true;
+}
+#include "syclblas_batch.cxx"
+#undef COLUMN_MAJOR
+
+} // namespace column_major
+namespace row_major {
+
+#define ROW_MAJOR
+constexpr bool is_column_major() {
+    return false;
+}
+#include "syclblas_batch.cxx"
+#undef ROW_MAJOR
+
+} // namespace row_major
+} // namespace syclblas
+} // namespace blas
+} // namespace mkl
+} // namespace oneapi

--- a/src/blas/backends/syclblas/syclblas_batch.cxx
+++ b/src/blas/backends/syclblas/syclblas_batch.cxx
@@ -1,0 +1,937 @@
+/*******************************************************************************
+* Copyright Codeplay Software
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+// Buffer APIs
+
+void syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1> &a,
+                std::int64_t lda, std::int64_t stride_a, float beta, sycl::buffer<float, 1> &c,
+                std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                std::int64_t n, std::int64_t k, double alpha, sycl::buffer<double, 1> &a,
+                std::int64_t lda, std::int64_t stride_a, double beta, sycl::buffer<double, 1> &c,
+                std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c,
+                std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                float alpha, sycl::buffer<float, 1> &a, std::int64_t lda, std::int64_t stridea,
+                sycl::buffer<float, 1> &x, std::int64_t incx, std::int64_t stridex, float beta,
+                sycl::buffer<float, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                double alpha, sycl::buffer<double, 1> &a, std::int64_t lda, std::int64_t stridea,
+                sycl::buffer<double, 1> &x, std::int64_t incx, std::int64_t stridex, double beta,
+                sycl::buffer<double, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+                std::int64_t lda, std::int64_t stridea, sycl::buffer<std::complex<float>, 1> &x,
+                std::int64_t incx, std::int64_t stridex, std::complex<float> beta,
+                sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+                std::int64_t lda, std::int64_t stridea, sycl::buffer<std::complex<double>, 1> &x,
+                std::int64_t incx, std::int64_t stridex, std::complex<double> beta,
+                sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
+                sycl::buffer<float, 1> &a, std::int64_t lda, std::int64_t stridea,
+                sycl::buffer<float, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<float, 1> &c, std::int64_t ldc, std::int64_t stridec,
+                std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
+                sycl::buffer<double, 1> &a, std::int64_t lda, std::int64_t stridea,
+                sycl::buffer<double, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<double, 1> &c, std::int64_t ldc, std::int64_t stridec,
+                std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
+                sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda, std::int64_t stridea,
+                sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc, std::int64_t stridec,
+                std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
+                sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda, std::int64_t stridea,
+                sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc, std::int64_t stridec,
+                std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void axpy_batch(sycl::queue &queue, std::int64_t n, float alpha, sycl::buffer<float, 1> &x,
+                std::int64_t incx, std::int64_t stridex, sycl::buffer<float, 1> &y,
+                std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void axpy_batch(sycl::queue &queue, std::int64_t n, double alpha, sycl::buffer<double, 1> &x,
+                std::int64_t incx, std::int64_t stridex, sycl::buffer<double, 1> &y,
+                std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void axpy_batch(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
+                sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void axpy_batch(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
+                sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::int64_t stridex,
+                sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy, std::int64_t stridey,
+                std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+void copy_batch(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
+                std::int64_t stridex, sycl::buffer<float, 1> &y, std::int64_t incy,
+                std::int64_t stridey, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void copy_batch(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
+                std::int64_t stridex, sycl::buffer<double, 1> &y, std::int64_t incy,
+                std::int64_t stridey, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void copy_batch(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+                std::int64_t incx, std::int64_t stridex, sycl::buffer<std::complex<float>, 1> &y,
+                std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void copy_batch(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+                std::int64_t incx, std::int64_t stridex, sycl::buffer<std::complex<double>, 1> &y,
+                std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                sycl::buffer<float, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<float, 1> &b, std::int64_t ldb, std::int64_t stride_b, float beta,
+                sycl::buffer<float, 1> &c, std::int64_t ldc, std::int64_t stride_c,
+                std::int64_t batch_size) {
+    // SYCL-BLAS's batched GEMM is for matrix strides equal to the size of the matrix only.
+    std::int64_t exp_stride_a =
+        (transa == transpose::nontrans) == is_column_major() ? lda * k : lda * m;
+    std::int64_t exp_stride_b =
+        (transb == transpose::nontrans) == is_column_major() ? ldb * n : ldb * k;
+    std::int64_t exp_stride_c = is_column_major() ? ldc * m : ldc * n;
+    if ((exp_stride_a == stride_a) && (exp_stride_b == stride_b) && (exp_stride_c == stride_c)) {
+        CALL_SYCLBLAS_FN(::blas::_gemm_batched, queue, transa, transb, m, n, k, alpha, a, lda, b,
+                         ldb, beta, c, ldc, batch_size, ::blas::gemm_batch_type_t::strided);
+    }
+    else {
+        throw std::runtime_error("Implemented in SYCL-BLAS for strides of matrix size only");
+    }
+}
+
+void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                std::int64_t m, std::int64_t n, std::int64_t k, double alpha,
+                sycl::buffer<double, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<double, 1> &b, std::int64_t ldb, std::int64_t stride_b, double beta,
+                sycl::buffer<double, 1> &c, std::int64_t ldc, std::int64_t stride_c,
+                std::int64_t batch_size) {
+    // SYCL-BLAS's batched GEMM is for matrix strides equal to the size of the matrix only.
+    std::int64_t exp_stride_a =
+        (transa == transpose::nontrans) == is_column_major() ? lda * k : lda * m;
+    std::int64_t exp_stride_b =
+        (transb == transpose::nontrans) == is_column_major() ? ldb * n : ldb * k;
+    std::int64_t exp_stride_c = is_column_major() ? ldc * m : ldc * n;
+    if ((exp_stride_a == stride_a) && (exp_stride_b == stride_b) && (exp_stride_c == stride_c)) {
+        CALL_SYCLBLAS_FN(::blas::_gemm_batched, queue, transa, transb, m, n, k, alpha, a, lda, b,
+                         ldb, beta, c, ldc, batch_size, ::blas::gemm_batch_type_t::strided);
+    }
+    else {
+        throw std::runtime_error("Implemented in SYCL-BLAS for strides of matrix size only");
+    }
+}
+
+void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c,
+                std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                sycl::buffer<sycl::half, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                sycl::half beta, sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
+                std::int64_t stride_c, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
+                std::int64_t n, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
+                std::int64_t stride_a, sycl::buffer<float, 1> &b, std::int64_t ldb,
+                std::int64_t stride_b, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
+                std::int64_t n, double alpha, sycl::buffer<double, 1> &a, std::int64_t lda,
+                std::int64_t stride_a, sycl::buffer<double, 1> &b, std::int64_t ldb,
+                std::int64_t stride_b, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
+                std::int64_t n, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+                std::int64_t lda, std::int64_t stride_a, sycl::buffer<std::complex<float>, 1> &b,
+                std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
+                std::int64_t n, std::complex<double> alpha,
+                sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::int64_t stride_b,
+                std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                    std::int64_t n, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
+                    std::int64_t stride_a, sycl::buffer<float, 1> &b, std::int64_t ldb,
+                    std::int64_t stride_b, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                    std::int64_t n, double alpha, sycl::buffer<double, 1> &a, std::int64_t lda,
+                    std::int64_t stride_a, sycl::buffer<double, 1> &b, std::int64_t ldb,
+                    std::int64_t stride_b, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                    std::int64_t n, std::complex<float> alpha,
+                    sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+                    std::int64_t stride_a, sycl::buffer<std::complex<float>, 1> &b,
+                    std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                    std::int64_t n, std::complex<double> alpha,
+                    sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+                    std::int64_t stride_a, sycl::buffer<std::complex<double>, 1> &b,
+                    std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                    std::int64_t n, float alpha, sycl::buffer<float, 1> &ab, std::int64_t lda,
+                    std::int64_t ldb, std::int64_t stride, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                    std::int64_t n, double alpha, sycl::buffer<double, 1> &ab, std::int64_t lda,
+                    std::int64_t ldb, std::int64_t stride, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                    std::int64_t n, std::complex<float> alpha,
+                    sycl::buffer<std::complex<float>, 1> &ab, std::int64_t lda, std::int64_t ldb,
+                    std::int64_t stride, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                    std::int64_t n, std::complex<double> alpha,
+                    sycl::buffer<std::complex<double>, 1> &ab, std::int64_t lda, std::int64_t ldb,
+                    std::int64_t stride, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                   std::int64_t m, std::int64_t n, float alpha, sycl::buffer<float, 1> &a,
+                   std::int64_t lda, std::int64_t stride_a, float beta, sycl::buffer<float, 1> &b,
+                   std::int64_t ldb, std::int64_t stride_b, sycl::buffer<float, 1> &c,
+                   std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                   std::int64_t m, std::int64_t n, double alpha, sycl::buffer<double, 1> &a,
+                   std::int64_t lda, std::int64_t stride_a, double beta, sycl::buffer<double, 1> &b,
+                   std::int64_t ldb, std::int64_t stride_b, sycl::buffer<double, 1> &c,
+                   std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                   std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                   sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda, std::int64_t stride_a,
+                   std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &b,
+                   std::int64_t ldb, std::int64_t stride_b, sycl::buffer<std::complex<float>, 1> &c,
+                   std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                   std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                   sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+                   std::int64_t stride_a, std::complex<double> beta,
+                   sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb,
+                   std::int64_t stride_b, sycl::buffer<std::complex<double>, 1> &c,
+                   std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+// USM APIs
+
+sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
+                       oneapi::mkl::transpose *trans, std::int64_t *n, std::int64_t *k,
+                       float *alpha, const float **a, std::int64_t *lda, float *beta, float **c,
+                       std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
+                       oneapi::mkl::transpose *trans, std::int64_t *n, std::int64_t *k,
+                       double *alpha, const double **a, std::int64_t *lda, double *beta, double **c,
+                       std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
+                       oneapi::mkl::transpose *trans, std::int64_t *n, std::int64_t *k,
+                       std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
+                       std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
+                       oneapi::mkl::transpose *trans, std::int64_t *n, std::int64_t *k,
+                       std::complex<double> *alpha, const std::complex<double> **a,
+                       std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
+                       std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                       oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k, float alpha,
+                       const float *a, std::int64_t lda, std::int64_t stride_a, float beta,
+                       float *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                       oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k, double alpha,
+                       const double *a, std::int64_t lda, std::int64_t stride_a, double beta,
+                       double *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                       oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                       std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
+                       std::int64_t stride_a, std::complex<float> beta, std::complex<float> *c,
+                       std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower,
+                       oneapi::mkl::transpose trans, std::int64_t n, std::int64_t k,
+                       std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
+                       std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c,
+                       std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                       std::int64_t n, float alpha, const float *a, std::int64_t lda,
+                       std::int64_t stridea, const float *x, std::int64_t incx,
+                       std::int64_t stridex, float beta, float *y, std::int64_t incy,
+                       std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                       std::int64_t n, double alpha, const double *a, std::int64_t lda,
+                       std::int64_t stridea, const double *x, std::int64_t incx,
+                       std::int64_t stridex, double beta, double *y, std::int64_t incy,
+                       std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                       std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
+                       std::int64_t lda, std::int64_t stridea, const std::complex<float> *x,
+                       std::int64_t incx, std::int64_t stridex, std::complex<float> beta,
+                       std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                       std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
+                       std::int64_t lda, std::int64_t stridea, const std::complex<double> *x,
+                       std::int64_t incx, std::int64_t stridex, std::complex<double> beta,
+                       std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m,
+                       std::int64_t *n, float *alpha, const float **a, std::int64_t *lda,
+                       const float **x, std::int64_t *incx, float *beta, float **y,
+                       std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m,
+                       std::int64_t *n, double *alpha, const double **a, std::int64_t *lda,
+                       const double **x, std::int64_t *incx, double *beta, double **y,
+                       std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m,
+                       std::int64_t *n, std::complex<float> *alpha, const std::complex<float> **a,
+                       std::int64_t *lda, const std::complex<float> **x, std::int64_t *incx,
+                       std::complex<float> *beta, std::complex<float> **y, std::int64_t *incy,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m,
+                       std::int64_t *n, std::complex<double> *alpha, const std::complex<double> **a,
+                       std::int64_t *lda, const std::complex<double> **x, std::int64_t *incx,
+                       std::complex<double> *beta, std::complex<double> **y, std::int64_t *incy,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m,
+                       std::int64_t n, const float *a, std::int64_t lda, std::int64_t stridea,
+                       const float *x, std::int64_t incx, std::int64_t stridex, float *c,
+                       std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m,
+                       std::int64_t n, const double *a, std::int64_t lda, std::int64_t stridea,
+                       const double *x, std::int64_t incx, std::int64_t stridex, double *c,
+                       std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m,
+                       std::int64_t n, const std::complex<float> *a, std::int64_t lda,
+                       std::int64_t stridea, const std::complex<float> *x, std::int64_t incx,
+                       std::int64_t stridex, std::complex<float> *c, std::int64_t ldc,
+                       std::int64_t stridec, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m,
+                       std::int64_t n, const std::complex<double> *a, std::int64_t lda,
+                       std::int64_t stridea, const std::complex<double> *x, std::int64_t incx,
+                       std::int64_t stridex, std::complex<double> *c, std::int64_t ldc,
+                       std::int64_t stridec, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m,
+                       std::int64_t *n, const float **a, std::int64_t *lda, const float **x,
+                       std::int64_t *incx, float **c, std::int64_t *ldc, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m,
+                       std::int64_t *n, const double **a, std::int64_t *lda, const double **x,
+                       std::int64_t *incx, double **c, std::int64_t *ldc, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m,
+                       std::int64_t *n, const std::complex<float> **a, std::int64_t *lda,
+                       const std::complex<float> **x, std::int64_t *incx, std::complex<float> **c,
+                       std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m,
+                       std::int64_t *n, const std::complex<double> **a, std::int64_t *lda,
+                       const std::complex<double> **x, std::int64_t *incx, std::complex<double> **c,
+                       std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpy_batch(sycl::queue &queue, std::int64_t *n, float *alpha, const float **x,
+                       std::int64_t *incx, float **y, std::int64_t *incy, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpy_batch(sycl::queue &queue, std::int64_t *n, double *alpha, const double **x,
+                       std::int64_t *incx, double **y, std::int64_t *incy, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpy_batch(sycl::queue &queue, std::int64_t *n, std::complex<float> *alpha,
+                       const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y,
+                       std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpy_batch(sycl::queue &queue, std::int64_t *n, std::complex<double> *alpha,
+                       const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
+                       std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpy_batch(sycl::queue &queue, std::int64_t n, float alpha, const float *x,
+                       std::int64_t incx, std::int64_t stridex, float *y, std::int64_t incy,
+                       std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpy_batch(sycl::queue &queue, std::int64_t n, double alpha, const double *x,
+                       std::int64_t incx, std::int64_t stridex, double *y, std::int64_t incy,
+                       std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpy_batch(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
+                       const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
+                       std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpy_batch(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
+                       const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
+                       std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event copy_batch(sycl::queue &queue, std::int64_t *n, const float **x, std::int64_t *incx,
+                       float **y, std::int64_t *incy, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event copy_batch(sycl::queue &queue, std::int64_t *n, const double **x, std::int64_t *incx,
+                       double **y, std::int64_t *incy, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event copy_batch(sycl::queue &queue, std::int64_t *n, const std::complex<float> **x,
+                       std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event copy_batch(sycl::queue &queue, std::int64_t *n, const std::complex<double> **x,
+                       std::int64_t *incx, std::complex<double> **y, std::int64_t *incy,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event copy_batch(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
+                       std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event copy_batch(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
+                       std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event copy_batch(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
+                       std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
+                       std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event copy_batch(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
+                       std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
+                       std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
+                       oneapi::mkl::transpose *transb, std::int64_t *m, std::int64_t *n,
+                       std::int64_t *k, float *alpha, const float **a, std::int64_t *lda,
+                       const float **b, std::int64_t *ldb, float *beta, float **c,
+                       std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
+                       oneapi::mkl::transpose *transb, std::int64_t *m, std::int64_t *n,
+                       std::int64_t *k, double *alpha, const double **a, std::int64_t *lda,
+                       const double **b, std::int64_t *ldb, double *beta, double **c,
+                       std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
+                       oneapi::mkl::transpose *transb, std::int64_t *m, std::int64_t *n,
+                       std::int64_t *k, std::complex<float> *alpha, const std::complex<float> **a,
+                       std::int64_t *lda, const std::complex<float> **b, std::int64_t *ldb,
+                       std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
+                       oneapi::mkl::transpose *transb, std::int64_t *m, std::int64_t *n,
+                       std::int64_t *k, std::complex<double> *alpha, const std::complex<double> **a,
+                       std::int64_t *lda, const std::complex<double> **b, std::int64_t *ldb,
+                       std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
+                       oneapi::mkl::transpose *transb, std::int64_t *m, std::int64_t *n,
+                       std::int64_t *k, sycl::half *alpha, const sycl::half **a, std::int64_t *lda,
+                       const sycl::half **b, std::int64_t *ldb, sycl::half *beta, sycl::half **c,
+                       std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
+                       oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                       std::int64_t k, float alpha, const float *a, std::int64_t lda,
+                       std::int64_t stride_a, const float *b, std::int64_t ldb,
+                       std::int64_t stride_b, float beta, float *c, std::int64_t ldc,
+                       std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
+                       oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                       std::int64_t k, double alpha, const double *a, std::int64_t lda,
+                       std::int64_t stride_a, const double *b, std::int64_t ldb,
+                       std::int64_t stride_b, double beta, double *c, std::int64_t ldc,
+                       std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
+                       oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                       std::int64_t k, std::complex<float> alpha, const std::complex<float> *a,
+                       std::int64_t lda, std::int64_t stride_a, const std::complex<float> *b,
+                       std::int64_t ldb, std::int64_t stride_b, std::complex<float> beta,
+                       std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
+                       oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                       std::int64_t k, std::complex<double> alpha, const std::complex<double> *a,
+                       std::int64_t lda, std::int64_t stride_a, const std::complex<double> *b,
+                       std::int64_t ldb, std::int64_t stride_b, std::complex<double> beta,
+                       std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
+                       std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
+                       oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                       std::int64_t k, sycl::half alpha, const sycl::half *a, std::int64_t lda,
+                       std::int64_t stride_a, const sycl::half *b, std::int64_t ldb,
+                       std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc,
+                       std::int64_t stride_c, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right,
+                       oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                       oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n, float alpha,
+                       const float *a, std::int64_t lda, std::int64_t stride_a, float *b,
+                       std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right,
+                       oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                       oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n, double alpha,
+                       const double *a, std::int64_t lda, std::int64_t stride_a, double *b,
+                       std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right,
+                       oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                       oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+                       std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
+                       std::int64_t stride_a, std::complex<float> *b, std::int64_t ldb,
+                       std::int64_t stride_b, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right,
+                       oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                       oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+                       std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
+                       std::int64_t stride_a, std::complex<double> *b, std::int64_t ldb,
+                       std::int64_t stride_b, std::int64_t batch_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side *left_right,
+                       oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
+                       oneapi::mkl::diag *unit_diag, std::int64_t *m, std::int64_t *n, float *alpha,
+                       const float **a, std::int64_t *lda, float **b, std::int64_t *ldb,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side *left_right,
+                       oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
+                       oneapi::mkl::diag *unit_diag, std::int64_t *m, std::int64_t *n,
+                       double *alpha, const double **a, std::int64_t *lda, double **b,
+                       std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side *left_right,
+                       oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
+                       oneapi::mkl::diag *unit_diag, std::int64_t *m, std::int64_t *n,
+                       std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
+                       std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
+                       std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side *left_right,
+                       oneapi::mkl::uplo *upper_lower, oneapi::mkl::transpose *trans,
+                       oneapi::mkl::diag *unit_diag, std::int64_t *m, std::int64_t *n,
+                       std::complex<double> *alpha, const std::complex<double> **a,
+                       std::int64_t *lda, std::complex<double> **b, std::int64_t *ldb,
+                       std::int64_t group_count, std::int64_t *group_size,
+                       const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                           std::int64_t n, float alpha, const float *a, std::int64_t lda,
+                           std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
+                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                           std::int64_t n, double alpha, const double *a, std::int64_t lda,
+                           std::int64_t stride_a, double *b, std::int64_t ldb,
+                           std::int64_t stride_b, std::int64_t batch_size,
+                           const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                           std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
+                           std::int64_t lda, std::int64_t stride_a, std::complex<float> *b,
+                           std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
+                           const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                           std::int64_t n, std::complex<double> alpha,
+                           const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
+                           std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
+                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                           std::int64_t n, float alpha, float *ab, std::int64_t lda,
+                           std::int64_t ldb, std::int64_t stride, std::int64_t batch_size,
+                           const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                           std::int64_t n, double alpha, double *ab, std::int64_t lda,
+                           std::int64_t ldb, std::int64_t stride, std::int64_t batch_size,
+                           const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                           std::int64_t n, std::complex<float> alpha, std::complex<float> *ab,
+                           std::int64_t lda, std::int64_t ldb, std::int64_t stride,
+                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
+                           std::int64_t n, std::complex<double> alpha, std::complex<double> *ab,
+                           std::int64_t lda, std::int64_t ldb, std::int64_t stride,
+                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
+                          oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                          float alpha, const float *a, std::int64_t lda, std::int64_t stride_a,
+                          float beta, const float *b, std::int64_t ldb, std::int64_t stride_b,
+                          float *c, std::int64_t ldc, std::int64_t stride_c,
+                          std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
+                          oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                          double alpha, const double *a, std::int64_t lda, std::int64_t stride_a,
+                          double beta, const double *b, std::int64_t ldb, std::int64_t stride_b,
+                          double *c, std::int64_t ldc, std::int64_t stride_c,
+                          std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
+                          oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                          std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
+                          std::int64_t stride_a, std::complex<float> beta,
+                          const std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
+                          std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
+                          std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
+                          oneapi::mkl::transpose transb, std::int64_t m, std::int64_t n,
+                          std::complex<double> alpha, const std::complex<double> *a,
+                          std::int64_t lda, std::int64_t stride_a, std::complex<double> beta,
+                          const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
+                          std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
+                          std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}

--- a/src/blas/backends/syclblas/syclblas_batch.cxx
+++ b/src/blas/backends/syclblas/syclblas_batch.cxx
@@ -23,14 +23,14 @@ void syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::
                 std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1> &a,
                 std::int64_t lda, std::int64_t stride_a, float beta, sycl::buffer<float, 1> &c,
                 std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk_batch", "");
 }
 
 void syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                 std::int64_t n, std::int64_t k, double alpha, sycl::buffer<double, 1> &a,
                 std::int64_t lda, std::int64_t stride_a, double beta, sycl::buffer<double, 1> &c,
                 std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk_batch", "");
 }
 
 void syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -38,7 +38,7 @@ void syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::
                 sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda, std::int64_t stride_a,
                 std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc,
                 std::int64_t stride_c, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk_batch", "");
 }
 
 void syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -46,7 +46,7 @@ void syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::
                 sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda, std::int64_t stride_a,
                 std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c,
                 std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk_batch", "");
 }
 
 void gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
@@ -54,7 +54,7 @@ void gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m
                 sycl::buffer<float, 1> &x, std::int64_t incx, std::int64_t stridex, float beta,
                 sycl::buffer<float, 1> &y, std::int64_t incy, std::int64_t stridey,
                 std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv_batch", "");
 }
 
 void gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
@@ -62,7 +62,7 @@ void gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m
                 sycl::buffer<double, 1> &x, std::int64_t incx, std::int64_t stridex, double beta,
                 sycl::buffer<double, 1> &y, std::int64_t incy, std::int64_t stridey,
                 std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv_batch", "");
 }
 
 void gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
@@ -71,7 +71,7 @@ void gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m
                 std::int64_t incx, std::int64_t stridex, std::complex<float> beta,
                 sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy, std::int64_t stridey,
                 std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv_batch", "");
 }
 
 void gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
@@ -80,7 +80,7 @@ void gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m
                 std::int64_t incx, std::int64_t stridex, std::complex<double> beta,
                 sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy, std::int64_t stridey,
                 std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv_batch", "");
 }
 
 void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
@@ -88,7 +88,7 @@ void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m
                 sycl::buffer<float, 1> &x, std::int64_t incx, std::int64_t stridex,
                 sycl::buffer<float, 1> &c, std::int64_t ldc, std::int64_t stridec,
                 std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dgmm_batch", "");
 }
 
 void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
@@ -96,7 +96,7 @@ void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m
                 sycl::buffer<double, 1> &x, std::int64_t incx, std::int64_t stridex,
                 sycl::buffer<double, 1> &c, std::int64_t ldc, std::int64_t stridec,
                 std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dgmm_batch", "");
 }
 
 void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
@@ -104,7 +104,7 @@ void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m
                 sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::int64_t stridex,
                 sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc, std::int64_t stridec,
                 std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dgmm_batch", "");
 }
 
 void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m, std::int64_t n,
@@ -112,56 +112,56 @@ void dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m
                 sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::int64_t stridex,
                 sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc, std::int64_t stridec,
                 std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dgmm_batch", "");
 }
 
 void axpy_batch(sycl::queue &queue, std::int64_t n, float alpha, sycl::buffer<float, 1> &x,
                 std::int64_t incx, std::int64_t stridex, sycl::buffer<float, 1> &y,
                 std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy_batch", "");
 }
 
 void axpy_batch(sycl::queue &queue, std::int64_t n, double alpha, sycl::buffer<double, 1> &x,
                 std::int64_t incx, std::int64_t stridex, sycl::buffer<double, 1> &y,
                 std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy_batch", "");
 }
 
 void axpy_batch(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                 sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::int64_t stridex,
                 sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy, std::int64_t stridey,
                 std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy_batch", "");
 }
 
 void axpy_batch(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                 sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::int64_t stridex,
                 sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy, std::int64_t stridey,
                 std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy_batch", "");
 }
 void copy_batch(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
                 std::int64_t stridex, sycl::buffer<float, 1> &y, std::int64_t incy,
                 std::int64_t stridey, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy_batch", "");
 }
 
 void copy_batch(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
                 std::int64_t stridex, sycl::buffer<double, 1> &y, std::int64_t incy,
                 std::int64_t stridey, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy_batch", "");
 }
 
 void copy_batch(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
                 std::int64_t incx, std::int64_t stridex, sycl::buffer<std::complex<float>, 1> &y,
                 std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy_batch", "");
 }
 
 void copy_batch(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
                 std::int64_t incx, std::int64_t stridex, sycl::buffer<std::complex<double>, 1> &y,
                 std::int64_t incy, std::int64_t stridey, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy_batch", "");
 }
 
 void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -181,7 +181,9 @@ void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::
                          ldb, beta, c, ldc, batch_size, ::blas::gemm_batch_type_t::strided);
     }
     else {
-        throw std::runtime_error("Implemented in SYCL-BLAS for strides of matrix size only");
+        throw unimplemented("blas", "gemm_batch",
+                            " for strides not equal to the size of the"
+                            "input / output matrices");
     }
 }
 
@@ -202,7 +204,9 @@ void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::
                          ldb, beta, c, ldc, batch_size, ::blas::gemm_batch_type_t::strided);
     }
     else {
-        throw std::runtime_error("Implemented in SYCL-BLAS for strides of matrix size only");
+        throw unimplemented("blas", "gemm_batch",
+                            " for strides not equal to the size of the"
+                            "input / output matrices");
     }
 }
 
@@ -212,7 +216,7 @@ void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::
                 sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::int64_t stride_b,
                 std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc,
                 std::int64_t stride_c, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for complex");
 }
 
 void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -221,7 +225,7 @@ void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::
                 sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::int64_t stride_b,
                 std::complex<double> beta, sycl::buffer<std::complex<double>, 1> &c,
                 std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for complex");
 }
 
 void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -230,7 +234,7 @@ void gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::
                 sycl::buffer<sycl::half, 1> &b, std::int64_t ldb, std::int64_t stride_b,
                 sycl::half beta, sycl::buffer<sycl::half, 1> &c, std::int64_t ldc,
                 std::int64_t stride_c, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for complex");
 }
 
 void trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -238,7 +242,7 @@ void trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::u
                 std::int64_t n, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
                 std::int64_t stride_a, sycl::buffer<float, 1> &b, std::int64_t ldb,
                 std::int64_t stride_b, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm_batch", "");
 }
 
 void trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -246,7 +250,7 @@ void trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::u
                 std::int64_t n, double alpha, sycl::buffer<double, 1> &a, std::int64_t lda,
                 std::int64_t stride_a, sycl::buffer<double, 1> &b, std::int64_t ldb,
                 std::int64_t stride_b, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm_batch", "");
 }
 
 void trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -254,7 +258,7 @@ void trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::u
                 std::int64_t n, std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
                 std::int64_t lda, std::int64_t stride_a, sycl::buffer<std::complex<float>, 1> &b,
                 std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm_batch", "");
 }
 
 void trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -263,21 +267,21 @@ void trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::u
                 sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda, std::int64_t stride_a,
                 sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::int64_t stride_b,
                 std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm_batch", "");
 }
 
 void omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
                     std::int64_t n, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
                     std::int64_t stride_a, sycl::buffer<float, 1> &b, std::int64_t ldb,
                     std::int64_t stride_b, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatcopy_batch", "");
 }
 
 void omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
                     std::int64_t n, double alpha, sycl::buffer<double, 1> &a, std::int64_t lda,
                     std::int64_t stride_a, sycl::buffer<double, 1> &b, std::int64_t ldb,
                     std::int64_t stride_b, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatcopy_batch", "");
 }
 
 void omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
@@ -285,7 +289,7 @@ void omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64
                     sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
                     std::int64_t stride_a, sycl::buffer<std::complex<float>, 1> &b,
                     std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatcopy_batch", "");
 }
 
 void omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
@@ -293,33 +297,33 @@ void omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64
                     sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
                     std::int64_t stride_a, sycl::buffer<std::complex<double>, 1> &b,
                     std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatcopy_batch", "");
 }
 
 void imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
                     std::int64_t n, float alpha, sycl::buffer<float, 1> &ab, std::int64_t lda,
                     std::int64_t ldb, std::int64_t stride, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "imatcopy_batch", "");
 }
 
 void imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
                     std::int64_t n, double alpha, sycl::buffer<double, 1> &ab, std::int64_t lda,
                     std::int64_t ldb, std::int64_t stride, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "imatcopy_batch", "");
 }
 
 void imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
                     std::int64_t n, std::complex<float> alpha,
                     sycl::buffer<std::complex<float>, 1> &ab, std::int64_t lda, std::int64_t ldb,
                     std::int64_t stride, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "imatcopy_batch", "");
 }
 
 void imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
                     std::int64_t n, std::complex<double> alpha,
                     sycl::buffer<std::complex<double>, 1> &ab, std::int64_t lda, std::int64_t ldb,
                     std::int64_t stride, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "imatcopy_batch", "");
 }
 
 void omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -327,7 +331,7 @@ void omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mk
                    std::int64_t lda, std::int64_t stride_a, float beta, sycl::buffer<float, 1> &b,
                    std::int64_t ldb, std::int64_t stride_b, sycl::buffer<float, 1> &c,
                    std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatadd_batch", "");
 }
 
 void omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -335,7 +339,7 @@ void omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mk
                    std::int64_t lda, std::int64_t stride_a, double beta, sycl::buffer<double, 1> &b,
                    std::int64_t ldb, std::int64_t stride_b, sycl::buffer<double, 1> &c,
                    std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatadd_batch", "");
 }
 
 void omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -344,7 +348,7 @@ void omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mk
                    std::complex<float> beta, sycl::buffer<std::complex<float>, 1> &b,
                    std::int64_t ldb, std::int64_t stride_b, sycl::buffer<std::complex<float>, 1> &c,
                    std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatadd_batch", "");
 }
 
 void omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -354,7 +358,7 @@ void omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mk
                    sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb,
                    std::int64_t stride_b, sycl::buffer<std::complex<double>, 1> &c,
                    std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatadd_batch", "");
 }
 
 // USM APIs
@@ -364,7 +368,7 @@ sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
                        float *alpha, const float **a, std::int64_t *lda, float *beta, float **c,
                        std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk_batch", " for USM");
 }
 
 sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
@@ -372,7 +376,7 @@ sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
                        double *alpha, const double **a, std::int64_t *lda, double *beta, double **c,
                        std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk_batch", " for USM");
 }
 
 sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
@@ -381,7 +385,7 @@ sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
                        std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
                        std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk_batch", " for USM");
 }
 
 sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
@@ -390,7 +394,7 @@ sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo *upper_lower,
                        std::int64_t *lda, std::complex<double> *beta, std::complex<double> **c,
                        std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk_batch", " for USM");
 }
 
 sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower,
@@ -398,7 +402,7 @@ sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                        const float *a, std::int64_t lda, std::int64_t stride_a, float beta,
                        float *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk_batch", " for USM");
 }
 
 sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower,
@@ -406,7 +410,7 @@ sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                        const double *a, std::int64_t lda, std::int64_t stride_a, double beta,
                        double *c, std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk_batch", " for USM");
 }
 
 sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower,
@@ -415,7 +419,7 @@ sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                        std::int64_t stride_a, std::complex<float> beta, std::complex<float> *c,
                        std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk_batch", " for USM");
 }
 
 sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower,
@@ -424,7 +428,7 @@ sycl::event syrk_batch(sycl::queue &queue, oneapi::mkl::uplo upper_lower,
                        std::int64_t stride_a, std::complex<double> beta, std::complex<double> *c,
                        std::int64_t ldc, std::int64_t stride_c, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk_batch", " for USM");
 }
 
 sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
@@ -433,7 +437,7 @@ sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::in
                        std::int64_t stridex, float beta, float *y, std::int64_t incy,
                        std::int64_t stridey, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv_batch", " for USM");
 }
 
 sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
@@ -442,7 +446,7 @@ sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::in
                        std::int64_t stridex, double beta, double *y, std::int64_t incy,
                        std::int64_t stridey, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv_batch", " for USM");
 }
 
 sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
@@ -451,7 +455,7 @@ sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::in
                        std::int64_t incx, std::int64_t stridex, std::complex<float> beta,
                        std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
                        std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv_batch", " for USM");
 }
 
 sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
@@ -460,7 +464,7 @@ sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::in
                        std::int64_t incx, std::int64_t stridex, std::complex<double> beta,
                        std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
                        std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv_batch", " for USM");
 }
 
 sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m,
@@ -468,7 +472,7 @@ sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::i
                        const float **x, std::int64_t *incx, float *beta, float **y,
                        std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv_batch", " for USM");
 }
 
 sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m,
@@ -476,7 +480,7 @@ sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::i
                        const double **x, std::int64_t *incx, double *beta, double **y,
                        std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv_batch", " for USM");
 }
 
 sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m,
@@ -485,7 +489,7 @@ sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::i
                        std::complex<float> *beta, std::complex<float> **y, std::int64_t *incy,
                        std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv_batch", " for USM");
 }
 
 sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::int64_t *m,
@@ -494,7 +498,7 @@ sycl::event gemv_batch(sycl::queue &queue, oneapi::mkl::transpose *trans, std::i
                        std::complex<double> *beta, std::complex<double> **y, std::int64_t *incy,
                        std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv_batch", " for USM");
 }
 
 sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m,
@@ -502,7 +506,7 @@ sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::in
                        const float *x, std::int64_t incx, std::int64_t stridex, float *c,
                        std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dgmm_batch", " for USM");
 }
 
 sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m,
@@ -510,7 +514,7 @@ sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::in
                        const double *x, std::int64_t incx, std::int64_t stridex, double *c,
                        std::int64_t ldc, std::int64_t stridec, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dgmm_batch", " for USM");
 }
 
 sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m,
@@ -519,7 +523,7 @@ sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::in
                        std::int64_t stridex, std::complex<float> *c, std::int64_t ldc,
                        std::int64_t stridec, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dgmm_batch", " for USM");
 }
 
 sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::int64_t m,
@@ -528,21 +532,21 @@ sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side left_right, std::in
                        std::int64_t stridex, std::complex<double> *c, std::int64_t ldc,
                        std::int64_t stridec, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dgmm_batch", " for USM");
 }
 
 sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m,
                        std::int64_t *n, const float **a, std::int64_t *lda, const float **x,
                        std::int64_t *incx, float **c, std::int64_t *ldc, std::int64_t group_count,
                        std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dgmm_batch", " for USM");
 }
 
 sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m,
                        std::int64_t *n, const double **a, std::int64_t *lda, const double **x,
                        std::int64_t *incx, double **c, std::int64_t *ldc, std::int64_t group_count,
                        std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dgmm_batch", " for USM");
 }
 
 sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m,
@@ -550,7 +554,7 @@ sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side *left_right, std::i
                        const std::complex<float> **x, std::int64_t *incx, std::complex<float> **c,
                        std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dgmm_batch", " for USM");
 }
 
 sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side *left_right, std::int64_t *m,
@@ -558,113 +562,113 @@ sycl::event dgmm_batch(sycl::queue &queue, oneapi::mkl::side *left_right, std::i
                        const std::complex<double> **x, std::int64_t *incx, std::complex<double> **c,
                        std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dgmm_batch", " for USM");
 }
 
 sycl::event axpy_batch(sycl::queue &queue, std::int64_t *n, float *alpha, const float **x,
                        std::int64_t *incx, float **y, std::int64_t *incy, std::int64_t group_count,
                        std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy_batch", " for USM");
 }
 
 sycl::event axpy_batch(sycl::queue &queue, std::int64_t *n, double *alpha, const double **x,
                        std::int64_t *incx, double **y, std::int64_t *incy, std::int64_t group_count,
                        std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy_batch", " for USM");
 }
 
 sycl::event axpy_batch(sycl::queue &queue, std::int64_t *n, std::complex<float> *alpha,
                        const std::complex<float> **x, std::int64_t *incx, std::complex<float> **y,
                        std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy_batch", " for USM");
 }
 
 sycl::event axpy_batch(sycl::queue &queue, std::int64_t *n, std::complex<double> *alpha,
                        const std::complex<double> **x, std::int64_t *incx, std::complex<double> **y,
                        std::int64_t *incy, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy_batch", " for USM");
 }
 
 sycl::event axpy_batch(sycl::queue &queue, std::int64_t n, float alpha, const float *x,
                        std::int64_t incx, std::int64_t stridex, float *y, std::int64_t incy,
                        std::int64_t stridey, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy_batch", " for USM");
 }
 
 sycl::event axpy_batch(sycl::queue &queue, std::int64_t n, double alpha, const double *x,
                        std::int64_t incx, std::int64_t stridex, double *y, std::int64_t incy,
                        std::int64_t stridey, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy_batch", " for USM");
 }
 
 sycl::event axpy_batch(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                        const std::complex<float> *x, std::int64_t incx, std::int64_t stridex,
                        std::complex<float> *y, std::int64_t incy, std::int64_t stridey,
                        std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy_batch", " for USM");
 }
 
 sycl::event axpy_batch(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                        const std::complex<double> *x, std::int64_t incx, std::int64_t stridex,
                        std::complex<double> *y, std::int64_t incy, std::int64_t stridey,
                        std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy_batch", " for USM");
 }
 
 sycl::event copy_batch(sycl::queue &queue, std::int64_t *n, const float **x, std::int64_t *incx,
                        float **y, std::int64_t *incy, std::int64_t group_count,
                        std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy_batch", " for USM");
 }
 
 sycl::event copy_batch(sycl::queue &queue, std::int64_t *n, const double **x, std::int64_t *incx,
                        double **y, std::int64_t *incy, std::int64_t group_count,
                        std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy_batch", " for USM");
 }
 
 sycl::event copy_batch(sycl::queue &queue, std::int64_t *n, const std::complex<float> **x,
                        std::int64_t *incx, std::complex<float> **y, std::int64_t *incy,
                        std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy_batch", " for USM");
 }
 
 sycl::event copy_batch(sycl::queue &queue, std::int64_t *n, const std::complex<double> **x,
                        std::int64_t *incx, std::complex<double> **y, std::int64_t *incy,
                        std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy_batch", " for USM");
 }
 
 sycl::event copy_batch(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                        std::int64_t stridex, float *y, std::int64_t incy, std::int64_t stridey,
                        std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy_batch", " for USM");
 }
 
 sycl::event copy_batch(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                        std::int64_t stridex, double *y, std::int64_t incy, std::int64_t stridey,
                        std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy_batch", " for USM");
 }
 
 sycl::event copy_batch(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                        std::int64_t incx, std::int64_t stridex, std::complex<float> *y,
                        std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy_batch", " for USM");
 }
 
 sycl::event copy_batch(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                        std::int64_t incx, std::int64_t stridex, std::complex<double> *y,
                        std::int64_t incy, std::int64_t stridey, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy_batch", " for USM");
 }
 
 sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
@@ -673,7 +677,7 @@ sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
                        const float **b, std::int64_t *ldb, float *beta, float **c,
                        std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for USM");
 }
 
 sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
@@ -682,7 +686,7 @@ sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
                        const double **b, std::int64_t *ldb, double *beta, double **c,
                        std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for USM");
 }
 
 sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
@@ -692,7 +696,7 @@ sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
                        std::complex<float> *beta, std::complex<float> **c, std::int64_t *ldc,
                        std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for USM");
 }
 
 sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
@@ -702,7 +706,7 @@ sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
                        std::complex<double> *beta, std::complex<double> **c, std::int64_t *ldc,
                        std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for USM");
 }
 
 sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
@@ -711,7 +715,7 @@ sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose *transa,
                        const sycl::half **b, std::int64_t *ldb, sycl::half *beta, sycl::half **c,
                        std::int64_t *ldc, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for USM");
 }
 
 sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -721,7 +725,7 @@ sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                        std::int64_t stride_b, float beta, float *c, std::int64_t ldc,
                        std::int64_t stride_c, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for USM");
 }
 
 sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -731,7 +735,7 @@ sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                        std::int64_t stride_b, double beta, double *c, std::int64_t ldc,
                        std::int64_t stride_c, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for USM");
 }
 
 sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -741,7 +745,7 @@ sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                        std::int64_t ldb, std::int64_t stride_b, std::complex<float> beta,
                        std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                        std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for USM");
 }
 
 sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -751,7 +755,7 @@ sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                        std::int64_t ldb, std::int64_t stride_b, std::complex<double> beta,
                        std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                        std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for USM");
 }
 
 sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -761,7 +765,7 @@ sycl::event gemm_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                        std::int64_t stride_b, sycl::half beta, sycl::half *c, std::int64_t ldc,
                        std::int64_t stride_c, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_batch", " for USM");
 }
 
 sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right,
@@ -770,7 +774,7 @@ sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right,
                        const float *a, std::int64_t lda, std::int64_t stride_a, float *b,
                        std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm_batch", " for USM");
 }
 
 sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right,
@@ -779,7 +783,7 @@ sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right,
                        const double *a, std::int64_t lda, std::int64_t stride_a, double *b,
                        std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm_batch", " for USM");
 }
 
 sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right,
@@ -789,7 +793,7 @@ sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right,
                        std::int64_t stride_a, std::complex<float> *b, std::int64_t ldb,
                        std::int64_t stride_b, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm_batch", " for USM");
 }
 
 sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right,
@@ -799,7 +803,7 @@ sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side left_right,
                        std::int64_t stride_a, std::complex<double> *b, std::int64_t ldb,
                        std::int64_t stride_b, std::int64_t batch_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm_batch", " for USM");
 }
 
 sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side *left_right,
@@ -808,7 +812,7 @@ sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side *left_right,
                        const float **a, std::int64_t *lda, float **b, std::int64_t *ldb,
                        std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm_batch", " for USM");
 }
 
 sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side *left_right,
@@ -817,7 +821,7 @@ sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side *left_right,
                        double *alpha, const double **a, std::int64_t *lda, double **b,
                        std::int64_t *ldb, std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm_batch", " for USM");
 }
 
 sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side *left_right,
@@ -826,7 +830,7 @@ sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side *left_right,
                        std::complex<float> *alpha, const std::complex<float> **a, std::int64_t *lda,
                        std::complex<float> **b, std::int64_t *ldb, std::int64_t group_count,
                        std::int64_t *group_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm_batch", " for USM");
 }
 
 sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side *left_right,
@@ -836,14 +840,14 @@ sycl::event trsm_batch(sycl::queue &queue, oneapi::mkl::side *left_right,
                        std::int64_t *lda, std::complex<double> **b, std::int64_t *ldb,
                        std::int64_t group_count, std::int64_t *group_size,
                        const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm_batch", " for USM");
 }
 
 sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
                            std::int64_t n, float alpha, const float *a, std::int64_t lda,
                            std::int64_t stride_a, float *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatcopy_batch", " for USM");
 }
 
 sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
@@ -851,7 +855,7 @@ sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std
                            std::int64_t stride_a, double *b, std::int64_t ldb,
                            std::int64_t stride_b, std::int64_t batch_size,
                            const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatcopy_batch", " for USM");
 }
 
 sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
@@ -859,7 +863,7 @@ sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std
                            std::int64_t lda, std::int64_t stride_a, std::complex<float> *b,
                            std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                            const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatcopy_batch", " for USM");
 }
 
 sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
@@ -867,35 +871,35 @@ sycl::event omatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std
                            const std::complex<double> *a, std::int64_t lda, std::int64_t stride_a,
                            std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
                            std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatcopy_batch", " for USM");
 }
 
 sycl::event imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
                            std::int64_t n, float alpha, float *ab, std::int64_t lda,
                            std::int64_t ldb, std::int64_t stride, std::int64_t batch_size,
                            const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "imatcopy_batch", " for USM");
 }
 
 sycl::event imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
                            std::int64_t n, double alpha, double *ab, std::int64_t lda,
                            std::int64_t ldb, std::int64_t stride, std::int64_t batch_size,
                            const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "imatcopy_batch", " for USM");
 }
 
 sycl::event imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
                            std::int64_t n, std::complex<float> alpha, std::complex<float> *ab,
                            std::int64_t lda, std::int64_t ldb, std::int64_t stride,
                            std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "imatcopy_batch", " for USM");
 }
 
 sycl::event imatcopy_batch(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m,
                            std::int64_t n, std::complex<double> alpha, std::complex<double> *ab,
                            std::int64_t lda, std::int64_t ldb, std::int64_t stride,
                            std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "imatcopy_batch", " for USM");
 }
 
 sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -904,7 +908,7 @@ sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                           float beta, const float *b, std::int64_t ldb, std::int64_t stride_b,
                           float *c, std::int64_t ldc, std::int64_t stride_c,
                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatadd_batch", " for USM");
 }
 
 sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -913,7 +917,7 @@ sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                           double beta, const double *b, std::int64_t ldb, std::int64_t stride_b,
                           double *c, std::int64_t ldc, std::int64_t stride_c,
                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatadd_batch", " for USM");
 }
 
 sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -923,7 +927,7 @@ sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                           const std::complex<float> *b, std::int64_t ldb, std::int64_t stride_b,
                           std::complex<float> *c, std::int64_t ldc, std::int64_t stride_c,
                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatadd_batch", " for USM");
 }
 
 sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -933,5 +937,5 @@ sycl::event omatadd_batch(sycl::queue &queue, oneapi::mkl::transpose transa,
                           const std::complex<double> *b, std::int64_t ldb, std::int64_t stride_b,
                           std::complex<double> *c, std::int64_t ldc, std::int64_t stride_c,
                           std::int64_t batch_size, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "omatadd_batch", " for USM");
 }

--- a/src/blas/backends/syclblas/syclblas_common.hpp
+++ b/src/blas/backends/syclblas/syclblas_common.hpp
@@ -1,0 +1,156 @@
+/*******************************************************************************
+* Copyright Codeplay Software
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#ifndef _SYCLBLAS_COMMON_HPP_
+#define _SYCLBLAS_COMMON_HPP_
+
+#include "sycl_blas.h"
+#include "oneapi/mkl/types.hpp"
+
+#include <tuple>
+#include <utility>
+
+namespace oneapi {
+namespace mkl {
+namespace blas {
+namespace syclblas {
+
+namespace detail {
+using policy_t = ::blas::codeplay_policy;
+using policy_handler_t = ::blas::PolicyHandler<policy_t>;
+
+// SYCL-BLAS executor type. Constructed with sycl::queue.
+using executor_t = ::blas::Executor<detail::policy_handler_t>;
+
+// SYCL-BLAS buffer iterator. Constructed with sycl::buffer<ElemT,1>
+template <typename ElemT>
+using buffer_iterator_t = ::blas::BufferIterator<ElemT, detail::policy_t>;
+
+/** A trait for obtaining equivalent SYCL-BLAS API types from oneMKL API
+ *  types.
+ * 
+ *  @tparam InputT is the oneMKL type.
+ *  syclblas_type<InputT>::type should be the equivalent SYCL-BLAS type.
+**/
+template <typename InputT>
+struct syclblas_type;
+
+#define DEF_SYCLBLAS_TYPE(onemkl_t, syclblas_t) \
+    template <>                                 \
+    struct syclblas_type<onemkl_t> {            \
+        using type = syclblas_t;                \
+    };
+
+DEF_SYCLBLAS_TYPE(sycl::queue, executor_t)
+DEF_SYCLBLAS_TYPE(int64_t, int32_t)
+DEF_SYCLBLAS_TYPE(float, float)
+DEF_SYCLBLAS_TYPE(double, double)
+DEF_SYCLBLAS_TYPE(oneapi::mkl::transpose, char)
+DEF_SYCLBLAS_TYPE(oneapi::mkl::uplo, char)
+DEF_SYCLBLAS_TYPE(oneapi::mkl::side, char)
+DEF_SYCLBLAS_TYPE(oneapi::mkl::diag, char)
+// Passthrough of SYCL-BLAS arg types for more complex wrapping.
+DEF_SYCLBLAS_TYPE(::blas::gemm_batch_type_t, ::blas::gemm_batch_type_t)
+
+#undef DEF_SYCLBLAS_TYPE
+
+template <typename ElemT>
+struct syclblas_type<sycl::buffer<ElemT, 1>> {
+    using type = buffer_iterator_t<ElemT>;
+};
+
+/** Convert a OneMKL argument to the type required for SYCL-BLAS.
+ *  
+ *  @tparam InputT The OneMKL type.
+ *  @param input The value of the oneMKL type.
+ *  @return The SYCL-BLAS value with appropriate type.
+**/
+template <typename InputT>
+inline typename syclblas_type<InputT>::type convert_to_syclblas_type(InputT& input) {
+    return typename syclblas_type<InputT>::type(input);
+}
+
+template <>
+inline char convert_to_syclblas_type<oneapi::mkl::transpose>(oneapi::mkl::transpose& trans) {
+    if (trans == oneapi::mkl::transpose::nontrans) {
+        return 'n';
+    }
+    else if (trans == oneapi::mkl::transpose::trans) {
+        return 't';
+    }
+    else { // trans == oneapi::mkl::transpose::conjtrans
+        return 'c';
+    }
+}
+
+template <>
+inline char convert_to_syclblas_type<oneapi::mkl::uplo>(oneapi::mkl::uplo& upper_lower) {
+    if (upper_lower == oneapi::mkl::uplo::upper) {
+        return 'u';
+    }
+    else {
+        return 'l';
+    }
+}
+
+template <>
+inline char convert_to_syclblas_type<oneapi::mkl::side>(oneapi::mkl::side& left_right) {
+    if (left_right == oneapi::mkl::side::left) {
+        return 'l';
+    }
+    else {
+        return 'r';
+    }
+}
+
+template <>
+inline char convert_to_syclblas_type<oneapi::mkl::diag>(oneapi::mkl::diag& unit_diag) {
+    if (unit_diag == oneapi::mkl::diag::unit) {
+        return 'u';
+    }
+    else {
+        return 'n';
+    }
+}
+
+template <typename... ArgT>
+inline auto convert_to_syclblas_type(ArgT... args) {
+    return std::make_tuple(convert_to_syclblas_type(args)...);
+}
+
+} // namespace detail
+
+#define CALL_SYCLBLAS_FN(syclblasFunc, ...)                        \
+    if constexpr ( is_column_major() ) {                           \
+        auto args = detail::convert_to_syclblas_type(__VA_ARGS__); \
+        auto fn = [](auto&&... targs) {                            \
+            syclblasFunc(std::forward<decltype(targs)>(targs)...); \
+        };                                                         \
+        std::apply(fn, args);                                      \
+    }                                                              \
+    else {                                                         \
+        std::runtime_error("SYCLBLAS supports column-major only"); \
+    }
+
+} // namespace syclblas
+} // namespace blas
+} // namespace mkl
+} // namespace oneapi
+
+#endif // _SYCLBLAS_COMMON_HPP_

--- a/src/blas/backends/syclblas/syclblas_level1.cpp
+++ b/src/blas/backends/syclblas/syclblas_level1.cpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+* Copyright Codeplay Software
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
+#include "syclblas_common.hpp"
+#include "oneapi/mkl/exceptions.hpp"
+#include "oneapi/mkl/blas/detail/syclblas/onemkl_blas_syclblas.hpp"
+
+namespace oneapi {
+namespace mkl {
+namespace blas {
+namespace syclblas {
+namespace column_major {
+
+#define COLUMN_MAJOR
+constexpr bool is_column_major() {
+    return true;
+}
+#include "syclblas_level1.cxx"
+#undef COLUMN_MAJOR
+
+} // namespace column_major
+namespace row_major {
+
+#define ROW_MAJOR
+constexpr bool is_column_major() {
+    return false;
+}
+#include "syclblas_level1.cxx"
+#undef ROW_MAJOR
+
+} // namespace row_major
+} // namespace syclblas
+} // namespace blas
+} // namespace mkl
+} // namespace oneapi

--- a/src/blas/backends/syclblas/syclblas_level1.cxx
+++ b/src/blas/backends/syclblas/syclblas_level1.cxx
@@ -1,0 +1,646 @@
+/*******************************************************************************
+* Copyright Codeplay Software
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+// Buffer APIs
+
+void dotc(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+          std::int64_t incx, sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void dotc(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+          std::int64_t incx, sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void dotu(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+          std::int64_t incx, sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void dotu(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+          std::int64_t incx, sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
+           sycl::buffer<std::int64_t, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
+           sycl::buffer<std::int64_t, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
+           sycl::buffer<std::int64_t, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
+           sycl::buffer<std::int64_t, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+           std::int64_t incx, sycl::buffer<std::int64_t, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void asum(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+          std::int64_t incx, sycl::buffer<float, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void asum(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+          std::int64_t incx, sycl::buffer<double, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void asum(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
+          sycl::buffer<float, 1> &result) {
+    CALL_SYCLBLAS_FN(::blas::_asum, queue, n, x, incx, result);
+}
+
+void asum(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
+          sycl::buffer<double, 1> &result) {
+    CALL_SYCLBLAS_FN(::blas::_asum, queue, n, x, incx, result);
+}
+
+void axpy(sycl::queue &queue, std::int64_t n, float alpha, sycl::buffer<float, 1> &x,
+          std::int64_t incx, sycl::buffer<float, 1> &y, std::int64_t incy) {
+    CALL_SYCLBLAS_FN(::blas::_axpy, queue, n, alpha, x, incx, y, incy);
+}
+
+void axpy(sycl::queue &queue, std::int64_t n, double alpha, sycl::buffer<double, 1> &x,
+          std::int64_t incx, sycl::buffer<double, 1> &y, std::int64_t incy) {
+    CALL_SYCLBLAS_FN(::blas::_axpy, queue, n, alpha, x, incx, y, incy);
+}
+
+void axpy(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void axpy(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void axpby(sycl::queue &queue, std::int64_t n, float alpha, sycl::buffer<float, 1> &x,
+           std::int64_t incx, float beta, sycl::buffer<float, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+    // TODO: UNCHECKED
+}
+
+void axpby(sycl::queue &queue, std::int64_t n, double alpha, sycl::buffer<double, 1> &x,
+           std::int64_t incx, double beta, sycl::buffer<double, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+    // TODO: UNCHECKED
+}
+
+void axpby(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
+           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
+           sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+    // TODO: UNCHECKED
+}
+
+void axpby(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
+           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+    // TODO: UNCHECKED
+}
+
+void copy(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
+          sycl::buffer<float, 1> &y, std::int64_t incy) {
+    CALL_SYCLBLAS_FN(::blas::_copy, queue, n, x, incx, y, incy);
+}
+
+void copy(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
+          sycl::buffer<double, 1> &y, std::int64_t incy) {
+    CALL_SYCLBLAS_FN(::blas::_copy, queue, n, x, incx, y, incy);
+}
+
+void copy(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+          std::int64_t incx, sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void copy(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+          std::int64_t incx, sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void dot(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
+         sycl::buffer<float, 1> &y, std::int64_t incy, sycl::buffer<float, 1> &result) {
+    CALL_SYCLBLAS_FN(::blas::_dot, queue, n, x, incx, y, incy, result);
+}
+
+void dot(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
+         sycl::buffer<double, 1> &y, std::int64_t incy, sycl::buffer<double, 1> &result) {
+    CALL_SYCLBLAS_FN(::blas::_dot, queue, n, x, incx, y, incy, result);
+}
+
+void dot(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
+         sycl::buffer<float, 1> &y, std::int64_t incy, sycl::buffer<double, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void sdsdot(sycl::queue &queue, std::int64_t n, float sb, sycl::buffer<float, 1> &x,
+            std::int64_t incx, sycl::buffer<float, 1> &y, std::int64_t incy,
+            sycl::buffer<float, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+void nrm2(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+          std::int64_t incx, sycl::buffer<float, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void nrm2(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+          std::int64_t incx, sycl::buffer<double, 1> &result) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void nrm2(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
+          sycl::buffer<float, 1> &result) {
+    CALL_SYCLBLAS_FN(::blas::_nrm2, queue, n, x, incx, result);
+}
+
+void nrm2(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
+          sycl::buffer<double, 1> &result) {
+    CALL_SYCLBLAS_FN(::blas::_nrm2, queue, n, x, incx, result);
+}
+
+void rot(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+         std::int64_t incx, sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy, float c,
+         float s) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void rot(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+         std::int64_t incx, sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy, double c,
+         double s) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void rot(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
+         sycl::buffer<float, 1> &y, std::int64_t incy, float c, float s) {
+    CALL_SYCLBLAS_FN(::blas::_rot, queue, n, x, incx, y, incy, c, s);
+}
+
+void rot(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
+         sycl::buffer<double, 1> &y, std::int64_t incy, double c, double s) {
+    CALL_SYCLBLAS_FN(::blas::_rot, queue, n, x, incx, y, incy, c, s);
+}
+
+void rotg(sycl::queue &queue, sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &b,
+          sycl::buffer<float, 1> &c, sycl::buffer<float, 1> &s) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void rotg(sycl::queue &queue, sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &b,
+          sycl::buffer<double, 1> &c, sycl::buffer<double, 1> &s) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void rotg(sycl::queue &queue, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &b, sycl::buffer<float, 1> &c,
+          sycl::buffer<std::complex<float>, 1> &s) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void rotg(sycl::queue &queue, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &b, sycl::buffer<double, 1> &c,
+          sycl::buffer<std::complex<double>, 1> &s) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void rotm(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
+          sycl::buffer<float, 1> &y, std::int64_t incy, sycl::buffer<float, 1> &param) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void rotm(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
+          sycl::buffer<double, 1> &y, std::int64_t incy, sycl::buffer<double, 1> &param) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void rotmg(sycl::queue &queue, sycl::buffer<float, 1> &d1, sycl::buffer<float, 1> &d2,
+           sycl::buffer<float, 1> &x1, float y1, sycl::buffer<float, 1> &param) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void rotmg(sycl::queue &queue, sycl::buffer<double, 1> &d1, sycl::buffer<double, 1> &d2,
+           sycl::buffer<double, 1> &x1, double y1, sycl::buffer<double, 1> &param) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void scal(sycl::queue &queue, std::int64_t n, float alpha, sycl::buffer<float, 1> &x,
+          std::int64_t incx) {
+    CALL_SYCLBLAS_FN(::blas::_scal, queue, n, alpha, x, incx);
+}
+
+void scal(sycl::queue &queue, std::int64_t n, double alpha, sycl::buffer<double, 1> &x,
+          std::int64_t incx) {
+    CALL_SYCLBLAS_FN(::blas::_scal, queue, n, alpha, x, incx);
+}
+
+void scal(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void scal(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void scal(sycl::queue &queue, std::int64_t n, float alpha, sycl::buffer<std::complex<float>, 1> &x,
+          std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void scal(sycl::queue &queue, std::int64_t n, double alpha,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void swap(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
+          sycl::buffer<float, 1> &y, std::int64_t incy) {
+    CALL_SYCLBLAS_FN(::blas::_swap, queue, n, x, incx, y, incy);
+}
+
+void swap(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
+          sycl::buffer<double, 1> &y, std::int64_t incy) {
+    CALL_SYCLBLAS_FN(::blas::_swap, queue, n, x, incx, y, incy);
+}
+
+void swap(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
+          std::int64_t incx, sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void swap(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
+          std::int64_t incx, sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+// USM APIs
+
+sycl::event dotc(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
+                 std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
+                 std::complex<float> *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dotc(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
+                 std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
+                 std::complex<double> *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dotu(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
+                 std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
+                 std::complex<float> *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dotu(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
+                 std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
+                 std::complex<double> *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event iamax(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
+                  std::int64_t *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event iamax(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
+                  std::int64_t *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event iamax(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
+                  std::int64_t incx, std::int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event iamax(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
+                  std::int64_t incx, std::int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event iamin(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
+                  std::int64_t *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event iamin(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
+                  std::int64_t *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event iamin(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
+                  std::int64_t incx, std::int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event iamin(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
+                  std::int64_t incx, std::int64_t *result,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event asum(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
+                 std::int64_t incx, float *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event asum(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
+                 std::int64_t incx, double *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event asum(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
+                 float *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event asum(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
+                 double *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpy(sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
+                 float *y, std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpy(sycl::queue &queue, std::int64_t n, double alpha, const double *x,
+                 std::int64_t incx, double *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpy(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpy(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+sycl::event axpby(sycl::queue &queue, std::int64_t n, float alpha, const float *x,
+                  std::int64_t incx, const float beta, float *y, std::int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpby(sycl::queue &queue, std::int64_t n, double alpha, const double *x,
+                  std::int64_t incx, const double beta, double *y, std::int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpby(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
+                  const std::complex<float> *x, std::int64_t incx, const std::complex<float> beta,
+                  std::complex<float> *y, std::int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event axpby(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
+                  const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
+                  std::complex<double> *y, std::int64_t incy,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event copy(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event copy(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event copy(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
+                 std::int64_t incx, std::complex<float> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event copy(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
+                 std::int64_t incx, std::complex<double> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+sycl::event dot(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
+                const float *y, std::int64_t incy, float *result,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dot(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
+                const double *y, std::int64_t incy, double *result,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event dot(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
+                const float *y, std::int64_t incy, double *result,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event sdsdot(sycl::queue &queue, std::int64_t n, float sb, const float *x, std::int64_t incx,
+                   const float *y, std::int64_t incy, float *result,
+                   const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event nrm2(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
+                 std::int64_t incx, float *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event nrm2(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
+                 std::int64_t incx, double *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event nrm2(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
+                 float *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event nrm2(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
+                 double *result, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event rot(sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
+                std::complex<float> *y, std::int64_t incy, float c, float s,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event rot(sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
+                std::complex<double> *y, std::int64_t incy, double c, double s,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event rot(sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
+                std::int64_t incy, float c, float s, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event rot(sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
+                std::int64_t incy, double c, double s,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event rotg(sycl::queue &queue, float *a, float *b, float *c, float *s,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event rotg(sycl::queue &queue, double *a, double *b, double *c, double *s,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event rotg(sycl::queue &queue, std::complex<float> *a, std::complex<float> *b, float *c,
+                 std::complex<float> *s, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event rotg(sycl::queue &queue, std::complex<double> *a, std::complex<double> *b, double *c,
+                 std::complex<double> *s, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event rotm(sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
+                 std::int64_t incy, float *param, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event rotm(sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
+                 std::int64_t incy, double *param, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event rotmg(sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event rotmg(sycl::queue &queue, double *d1, double *d2, double *x1, double y1, double *param,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event scal(sycl::queue &queue, std::int64_t n, float alpha, float *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event scal(sycl::queue &queue, std::int64_t n, double alpha, double *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event scal(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
+                 std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event scal(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
+                 std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event scal(sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event scal(sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event swap(sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event swap(sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event swap(sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
+                 std::complex<float> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event swap(sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
+                 std::complex<double> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}

--- a/src/blas/backends/syclblas/syclblas_level1.cxx
+++ b/src/blas/backends/syclblas/syclblas_level1.cxx
@@ -22,75 +22,75 @@
 void dotc(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
           std::int64_t incx, sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
           sycl::buffer<std::complex<float>, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dotc", "");
 }
 
 void dotc(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
           std::int64_t incx, sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
           sycl::buffer<std::complex<double>, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dotc", "");
 }
 
 void dotu(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
           std::int64_t incx, sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
           sycl::buffer<std::complex<float>, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dotu", "");
 }
 
 void dotu(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
           std::int64_t incx, sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
           sycl::buffer<std::complex<double>, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dotu", "");
 }
 
 void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamax", "");
 }
 
 void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamax", "");
 }
 
 void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamax", "");
 }
 
 void iamax(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamax", "");
 }
 
 void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamin", "");
 }
 
 void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamin", "");
 }
 
 void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamin", "");
 }
 
 void iamin(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamin", "");
 }
 
 void asum(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
           std::int64_t incx, sycl::buffer<float, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "asum", "");
 }
 
 void asum(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
           std::int64_t incx, sycl::buffer<double, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "asum", "");
 }
 
 void asum(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
@@ -116,39 +116,35 @@ void axpy(sycl::queue &queue, std::int64_t n, double alpha, sycl::buffer<double,
 void axpy(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
           sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy", "for complex");
 }
 
 void axpy(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
           sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy", "for complex");
 }
 
 void axpby(sycl::queue &queue, std::int64_t n, float alpha, sycl::buffer<float, 1> &x,
            std::int64_t incx, float beta, sycl::buffer<float, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
-    // TODO: UNCHECKED
+    throw unimplemented("blas", "axpby", "");
 }
 
 void axpby(sycl::queue &queue, std::int64_t n, double alpha, sycl::buffer<double, 1> &x,
            std::int64_t incx, double beta, sycl::buffer<double, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
-    // TODO: UNCHECKED
+    throw unimplemented("blas", "axpby", "");
 }
 
 void axpby(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
            sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
            sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
-    // TODO: UNCHECKED
+    throw unimplemented("blas", "axpby", "");
 }
 
 void axpby(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
            sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
            sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
-    // TODO: UNCHECKED
+    throw unimplemented("blas", "axpby", "");
 }
 
 void copy(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
@@ -163,12 +159,12 @@ void copy(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::i
 
 void copy(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
           std::int64_t incx, sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy", " for complex.");
 }
 
 void copy(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
           std::int64_t incx, sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy", " for complex.");
 }
 
 void dot(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
@@ -183,22 +179,22 @@ void dot(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::in
 
 void dot(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
          sycl::buffer<float, 1> &y, std::int64_t incy, sycl::buffer<double, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dot", " for unmatched return type");
 }
 
 void sdsdot(sycl::queue &queue, std::int64_t n, float sb, sycl::buffer<float, 1> &x,
             std::int64_t incx, sycl::buffer<float, 1> &y, std::int64_t incy,
             sycl::buffer<float, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "sdsdot", "");
 }
 void nrm2(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
           std::int64_t incx, sycl::buffer<float, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "nrm2", " for complex");
 }
 
 void nrm2(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
           std::int64_t incx, sycl::buffer<double, 1> &result) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "nrm2", " for complex");
 }
 
 void nrm2(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
@@ -214,13 +210,13 @@ void nrm2(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::i
 void rot(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
          std::int64_t incx, sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy, float c,
          float s) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rot", " for complex");
 }
 
 void rot(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
          std::int64_t incx, sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy, double c,
          double s) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rot", " for complex");
 }
 
 void rot(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
@@ -235,44 +231,44 @@ void rot(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::in
 
 void rotg(sycl::queue &queue, sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &b,
           sycl::buffer<float, 1> &c, sycl::buffer<float, 1> &s) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotg", "");
 }
 
 void rotg(sycl::queue &queue, sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &b,
           sycl::buffer<double, 1> &c, sycl::buffer<double, 1> &s) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotg", "");
 }
 
 void rotg(sycl::queue &queue, sycl::buffer<std::complex<float>, 1> &a,
           sycl::buffer<std::complex<float>, 1> &b, sycl::buffer<float, 1> &c,
           sycl::buffer<std::complex<float>, 1> &s) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotg", "");
 }
 
 void rotg(sycl::queue &queue, sycl::buffer<std::complex<double>, 1> &a,
           sycl::buffer<std::complex<double>, 1> &b, sycl::buffer<double, 1> &c,
           sycl::buffer<std::complex<double>, 1> &s) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotg", "");
 }
 
 void rotm(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
           sycl::buffer<float, 1> &y, std::int64_t incy, sycl::buffer<float, 1> &param) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotm", "");
 }
 
 void rotm(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::int64_t incx,
           sycl::buffer<double, 1> &y, std::int64_t incy, sycl::buffer<double, 1> &param) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotm", "");
 }
 
 void rotmg(sycl::queue &queue, sycl::buffer<float, 1> &d1, sycl::buffer<float, 1> &d2,
            sycl::buffer<float, 1> &x1, float y1, sycl::buffer<float, 1> &param) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotmg", "");
 }
 
 void rotmg(sycl::queue &queue, sycl::buffer<double, 1> &d1, sycl::buffer<double, 1> &d2,
            sycl::buffer<double, 1> &x1, double y1, sycl::buffer<double, 1> &param) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotmg", "");
 }
 
 void scal(sycl::queue &queue, std::int64_t n, float alpha, sycl::buffer<float, 1> &x,
@@ -287,22 +283,22 @@ void scal(sycl::queue &queue, std::int64_t n, double alpha, sycl::buffer<double,
 
 void scal(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "scal", " for complex");
 }
 
 void scal(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "scal", " for complex");
 }
 
 void scal(sycl::queue &queue, std::int64_t n, float alpha, sycl::buffer<std::complex<float>, 1> &x,
           std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "scal", " for complex");
 }
 
 void scal(sycl::queue &queue, std::int64_t n, double alpha,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "scal", " for complex");
 }
 
 void swap(sycl::queue &queue, std::int64_t n, sycl::buffer<float, 1> &x, std::int64_t incx,
@@ -317,12 +313,12 @@ void swap(sycl::queue &queue, std::int64_t n, sycl::buffer<double, 1> &x, std::i
 
 void swap(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<float>, 1> &x,
           std::int64_t incx, sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "swap", " for complex");
 }
 
 void swap(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>, 1> &x,
           std::int64_t incx, sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "swap", " for complex");
 }
 
 // USM APIs
@@ -330,317 +326,319 @@ void swap(sycl::queue &queue, std::int64_t n, sycl::buffer<std::complex<double>,
 sycl::event dotc(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                  std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                  std::complex<float> *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dotc", " for USM");
 }
 
 sycl::event dotc(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                  std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                  std::complex<double> *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dotc", " for USM");
 }
 
 sycl::event dotu(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                  std::int64_t incx, const std::complex<float> *y, std::int64_t incy,
                  std::complex<float> *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dotu", " for USM");
 }
 
 sycl::event dotu(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                  std::int64_t incx, const std::complex<double> *y, std::int64_t incy,
                  std::complex<double> *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dotu", " for USM");
 }
 
 sycl::event iamax(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                   std::int64_t *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamax", " for USM");
 }
 
 sycl::event iamax(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                   std::int64_t *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamax", " for USM");
 }
 
 sycl::event iamax(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                   std::int64_t incx, std::int64_t *result,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamax", " for USM");
 }
 
 sycl::event iamax(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                   std::int64_t incx, std::int64_t *result,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamax", " for USM");
 }
 
 sycl::event iamin(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                   std::int64_t *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamin", " for USM");
 }
 
 sycl::event iamin(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                   std::int64_t *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamin", " for USM");
 }
 
 sycl::event iamin(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                   std::int64_t incx, std::int64_t *result,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamin", " for USM");
 }
 
 sycl::event iamin(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                   std::int64_t incx, std::int64_t *result,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "iamin", " for USM");
 }
 
 sycl::event asum(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                  std::int64_t incx, float *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "asum", " for USM");
 }
 
 sycl::event asum(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                  std::int64_t incx, double *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "asum", " for USM");
 }
 
 sycl::event asum(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                  float *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "asum", " for USM");
 }
 
 sycl::event asum(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                  double *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "asum", " for USM");
 }
 
 sycl::event axpy(sycl::queue &queue, std::int64_t n, float alpha, const float *x, std::int64_t incx,
                  float *y, std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy", " for USM");
 }
 
 sycl::event axpy(sycl::queue &queue, std::int64_t n, double alpha, const double *x,
                  std::int64_t incx, double *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy", " for USM");
 }
 
 sycl::event axpy(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                  const std::complex<float> *x, std::int64_t incx, std::complex<float> *y,
                  std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy", " for USM");
 }
 
 sycl::event axpy(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                  const std::complex<double> *x, std::int64_t incx, std::complex<double> *y,
                  std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpy", " for USM");
 }
+
 sycl::event axpby(sycl::queue &queue, std::int64_t n, float alpha, const float *x,
                   std::int64_t incx, const float beta, float *y, std::int64_t incy,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpby", " for USM");
 }
 
 sycl::event axpby(sycl::queue &queue, std::int64_t n, double alpha, const double *x,
                   std::int64_t incx, const double beta, double *y, std::int64_t incy,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpby", " for USM");
 }
 
 sycl::event axpby(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                   const std::complex<float> *x, std::int64_t incx, const std::complex<float> beta,
                   std::complex<float> *y, std::int64_t incy,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpby", " for USM");
 }
 
 sycl::event axpby(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                   const std::complex<double> *x, std::int64_t incx, const std::complex<double> beta,
                   std::complex<double> *y, std::int64_t incy,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "axpby", " for USM");
 }
 
 sycl::event copy(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx, float *y,
                  std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy", " for USM");
 }
 
 sycl::event copy(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx, double *y,
                  std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy", " for USM");
 }
 
 sycl::event copy(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                  std::int64_t incx, std::complex<float> *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy", " for USM");
 }
 
 sycl::event copy(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                  std::int64_t incx, std::complex<double> *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "copy", " for USM");
 }
+
 sycl::event dot(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                 const float *y, std::int64_t incy, float *result,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dot", " for USM");
 }
 
 sycl::event dot(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                 const double *y, std::int64_t incy, double *result,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dot", " for USM");
 }
 
 sycl::event dot(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                 const float *y, std::int64_t incy, double *result,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "dot", " for USM");
 }
 
 sycl::event sdsdot(sycl::queue &queue, std::int64_t n, float sb, const float *x, std::int64_t incx,
                    const float *y, std::int64_t incy, float *result,
                    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "sdsdot", " for USM");
 }
 
 sycl::event nrm2(sycl::queue &queue, std::int64_t n, const std::complex<float> *x,
                  std::int64_t incx, float *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "nrm2", " for USM");
 }
 
 sycl::event nrm2(sycl::queue &queue, std::int64_t n, const std::complex<double> *x,
                  std::int64_t incx, double *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "nrm2", " for USM");
 }
 
 sycl::event nrm2(sycl::queue &queue, std::int64_t n, const float *x, std::int64_t incx,
                  float *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "nrm2", " for USM");
 }
 
 sycl::event nrm2(sycl::queue &queue, std::int64_t n, const double *x, std::int64_t incx,
                  double *result, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "nrm2", " for USM");
 }
 
 sycl::event rot(sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
                 std::complex<float> *y, std::int64_t incy, float c, float s,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rot", " for USM");
 }
 
 sycl::event rot(sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
                 std::complex<double> *y, std::int64_t incy, double c, double s,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rot", " for USM");
 }
 
 sycl::event rot(sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
                 std::int64_t incy, float c, float s, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rot", " for USM");
 }
 
 sycl::event rot(sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
                 std::int64_t incy, double c, double s,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rot", " for USM");
 }
 
 sycl::event rotg(sycl::queue &queue, float *a, float *b, float *c, float *s,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotg", " for USM");
 }
 
 sycl::event rotg(sycl::queue &queue, double *a, double *b, double *c, double *s,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotg", " for USM");
 }
 
 sycl::event rotg(sycl::queue &queue, std::complex<float> *a, std::complex<float> *b, float *c,
                  std::complex<float> *s, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotg", " for USM");
 }
 
 sycl::event rotg(sycl::queue &queue, std::complex<double> *a, std::complex<double> *b, double *c,
                  std::complex<double> *s, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotg", " for USM");
 }
 
 sycl::event rotm(sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
                  std::int64_t incy, float *param, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotm", " for USM");
 }
 
 sycl::event rotm(sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
                  std::int64_t incy, double *param, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotm", " for USM");
 }
 
 sycl::event rotmg(sycl::queue &queue, float *d1, float *d2, float *x1, float y1, float *param,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotmg", " for USM");
 }
 
 sycl::event rotmg(sycl::queue &queue, double *d1, double *d2, double *x1, double y1, double *param,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "rotmg", " for USM");
 }
 
 sycl::event scal(sycl::queue &queue, std::int64_t n, float alpha, float *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "scal", " for USM");
 }
 
 sycl::event scal(sycl::queue &queue, std::int64_t n, double alpha, double *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "scal", " for USM");
 }
 
 sycl::event scal(sycl::queue &queue, std::int64_t n, std::complex<float> alpha,
                  std::complex<float> *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "scal", " for USM");
 }
 
 sycl::event scal(sycl::queue &queue, std::int64_t n, std::complex<double> alpha,
                  std::complex<double> *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "scal", " for USM");
 }
 
 sycl::event scal(sycl::queue &queue, std::int64_t n, float alpha, std::complex<float> *x,
                  std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "scal", " for USM");
 }
 
 sycl::event scal(sycl::queue &queue, std::int64_t n, double alpha, std::complex<double> *x,
                  std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "scal", " for USM");
 }
 
 sycl::event swap(sycl::queue &queue, std::int64_t n, float *x, std::int64_t incx, float *y,
                  std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "swap", " for USM");
 }
 
 sycl::event swap(sycl::queue &queue, std::int64_t n, double *x, std::int64_t incx, double *y,
                  std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "swap", " for USM");
 }
 
 sycl::event swap(sycl::queue &queue, std::int64_t n, std::complex<float> *x, std::int64_t incx,
                  std::complex<float> *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "swap", " for USM");
 }
 
 sycl::event swap(sycl::queue &queue, std::int64_t n, std::complex<double> *x, std::int64_t incx,
                  std::complex<double> *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "swap", " for USM");
 }

--- a/src/blas/backends/syclblas/syclblas_level2.cpp
+++ b/src/blas/backends/syclblas/syclblas_level2.cpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+* Copyright Codeplay Software
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
+#include "syclblas_common.hpp"
+#include "oneapi/mkl/exceptions.hpp"
+#include "oneapi/mkl/blas/detail/syclblas/onemkl_blas_syclblas.hpp"
+
+namespace oneapi {
+namespace mkl {
+namespace blas {
+namespace syclblas {
+namespace column_major {
+
+#define COLUMN_MAJOR
+constexpr bool is_column_major() {
+    return true;
+}
+#include "syclblas_level2.cxx"
+#undef COLUMN_MAJOR
+
+} // namespace column_major
+namespace row_major {
+
+#define ROW_MAJOR
+constexpr bool is_column_major() {
+    return false;
+}
+#include "syclblas_level2.cxx"
+#undef ROW_MAJOR
+
+} // namespace row_major
+} // namespace syclblas
+} // namespace blas
+} // namespace mkl
+} // namespace oneapi

--- a/src/blas/backends/syclblas/syclblas_level2.cxx
+++ b/src/blas/backends/syclblas/syclblas_level2.cxx
@@ -35,28 +35,28 @@ void gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std:
           std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
           sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv", " for complex");
 }
 
 void gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
           std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
           sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv", " for complex");
 }
 
 void gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
           std::int64_t kl, std::int64_t ku, float alpha, sycl::buffer<float, 1> &a,
           std::int64_t lda, sycl::buffer<float, 1> &x, std::int64_t incx, float beta,
           sycl::buffer<float, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gbmv", "");
 }
 
 void gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
           std::int64_t kl, std::int64_t ku, double alpha, sycl::buffer<double, 1> &a,
           std::int64_t lda, sycl::buffer<double, 1> &x, std::int64_t incx, double beta,
           sycl::buffer<double, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gbmv", "");
 }
 
 void gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
@@ -64,7 +64,7 @@ void gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std:
           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
           sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gbmv", "");
 }
 
 void gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
@@ -72,7 +72,7 @@ void gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std:
           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
           sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gbmv", "");
 }
 
 void ger(sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha, sycl::buffer<float, 1> &x,
@@ -91,133 +91,133 @@ void gerc(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
           sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gerc", "");
 }
 
 void gerc(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
           sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gerc", "");
 }
 
 void geru(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
           sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "geru", "");
 }
 
 void geru(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
           sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "geru", "");
 }
 
 void hbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
           std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
           sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hbmv", "");
 }
 
 void hbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
           std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
           sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hbmv", "");
 }
 
 void hemv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
           std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
           sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hemv", "");
 }
 
 void hemv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
           std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
           sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hemv", "");
 }
 
 void her(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "her", "");
 }
 
 void her(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "her", "");
 }
 void her2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
           std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
           sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "her2", "");
 }
 
 void her2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
           std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
           sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "her2", "");
 }
 
 void hpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
           std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
           sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hpmv", "");
 }
 
 void hpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
           std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
           sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hpmv", "");
 }
 
 void hpr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
          sycl::buffer<std::complex<float>, 1> &a) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hpr", "");
 }
 
 void hpr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
          sycl::buffer<std::complex<double>, 1> &a) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hpr", "");
 }
 
 void hpr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
           std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
           sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
           sycl::buffer<std::complex<float>, 1> &a) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hpr2", "");
 }
 
 void hpr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
           std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
           sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
           sycl::buffer<std::complex<double>, 1> &a) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hpr2", "");
 }
 
 void sbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
           float alpha, sycl::buffer<float, 1> &a, std::int64_t lda, sycl::buffer<float, 1> &x,
           std::int64_t incx, float beta, sycl::buffer<float, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "sbmv", "");
 }
 
 void sbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
           double alpha, sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &x,
           std::int64_t incx, double beta, sycl::buffer<double, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "sbmv", "");
 }
 
 void symv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
@@ -259,134 +259,134 @@ void syr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, dou
 void spmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
           sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &x, std::int64_t incx, float beta,
           sycl::buffer<float, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "spmv", "");
 }
 
 void spmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
           sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &x, std::int64_t incx, double beta,
           sycl::buffer<double, 1> &y, std::int64_t incy) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "spmv", "");
 }
 
 void spr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
          sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &a) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "spr", "");
 }
 
 void spr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
          sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &a) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "spr", "");
 }
 
 void spr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
           sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &y,
           std::int64_t incy, sycl::buffer<float, 1> &a) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "spr2", "");
 }
 
 void spr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
           sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &y,
           std::int64_t incy, sycl::buffer<double, 1> &a) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "spr2", "");
 }
 
 void tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<float, 1> &a,
           std::int64_t lda, sycl::buffer<float, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbmv", "");
 }
 
 void tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<double, 1> &a,
           std::int64_t lda, sycl::buffer<double, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbmv", "");
 }
 
 void tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbmv", "");
 }
 
 void tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbmv", "");
 }
 
 void tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<float, 1> &a,
           std::int64_t lda, sycl::buffer<float, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbsv", "");
 }
 
 void tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<double, 1> &a,
           std::int64_t lda, sycl::buffer<double, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbsv", "");
 }
 
 void tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbsv", "");
 }
 
 void tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbsv", "");
 }
 
 void tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<float, 1> &a,
           sycl::buffer<float, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpmv", "");
 }
 
 void tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<double, 1> &a,
           sycl::buffer<double, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpmv", "");
 }
 
 void tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<float>, 1> &a,
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpmv", "");
 }
 
 void tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<double>, 1> &a,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpmv", "");
 }
 void tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<float, 1> &a,
           sycl::buffer<float, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpsv", "");
 }
 
 void tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<double, 1> &a,
           sycl::buffer<double, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpsv", "");
 }
 
 void tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<float>, 1> &a,
           sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpsv", "");
 }
 
 void tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<double>, 1> &a,
           sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpsv", "");
 }
 
 void trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -404,36 +404,36 @@ void trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transp
 void trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<float>, 1> &a,
           std::int64_t lda, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmv", " for complex");
 }
 
 void trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<double>, 1> &a,
           std::int64_t lda, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmv", " for complex");
 }
 void trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<float, 1> &a, std::int64_t lda,
           sycl::buffer<float, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsv", "");
 }
 
 void trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<double, 1> &a, std::int64_t lda,
           sycl::buffer<double, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsv", "");
 }
 
 void trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<float>, 1> &a,
           std::int64_t lda, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsv", "");
 }
 
 void trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<double>, 1> &a,
           std::int64_t lda, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsv", "");
 }
 
 // USM APIs
@@ -442,14 +442,14 @@ sycl::event gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t 
                  float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
                  float beta, float *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv", " for USM");
 }
 
 sycl::event gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                  double alpha, const double *a, std::int64_t lda, const double *x,
                  std::int64_t incx, double beta, double *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv", " for USM");
 }
 
 sycl::event gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
@@ -457,7 +457,7 @@ sycl::event gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t 
                  const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                  std::complex<float> *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv", " for USM");
 }
 
 sycl::event gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
@@ -465,21 +465,21 @@ sycl::event gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t 
                  const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                  std::complex<double> *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemv", " for USM");
 }
 
 sycl::event gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                  std::int64_t kl, std::int64_t ku, float alpha, const float *a, std::int64_t lda,
                  const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gbmv", " for USM");
 }
 
 sycl::event gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
                  std::int64_t kl, std::int64_t ku, double alpha, const double *a, std::int64_t lda,
                  const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gbmv", " for USM");
 }
 
 sycl::event gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
@@ -487,7 +487,7 @@ sycl::event gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t 
                  const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
                  std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
                  std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gbmv", " for USM");
 }
 
 sycl::event gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
@@ -495,47 +495,47 @@ sycl::event gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t 
                  const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
                  std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
                  std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gbmv", " for USM");
 }
 
 sycl::event ger(sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha, const float *x,
                 std::int64_t incx, const float *y, std::int64_t incy, float *a, std::int64_t lda,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "ger", " for USM");
 }
 
 sycl::event ger(sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha, const double *x,
                 std::int64_t incx, const double *y, std::int64_t incy, double *a, std::int64_t lda,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "ger", " for USM");
 }
 
 sycl::event gerc(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                  const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                  std::int64_t incy, std::complex<float> *a, std::int64_t lda,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gerc", " for USM");
 }
 
 sycl::event gerc(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                  const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
                  std::int64_t incy, std::complex<double> *a, std::int64_t lda,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gerc", " for USM");
 }
 
 sycl::event geru(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
                  const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
                  std::int64_t incy, std::complex<float> *a, std::int64_t lda,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "geru", " for USM");
 }
 
 sycl::event geru(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
                  const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
                  std::int64_t incy, std::complex<double> *a, std::int64_t lda,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "geru", " for USM");
 }
 
 sycl::event hbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
@@ -543,7 +543,7 @@ sycl::event hbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t
                  const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                  std::complex<float> *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hbmv", " for USM");
 }
 
 sycl::event hbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
@@ -551,7 +551,7 @@ sycl::event hbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t
                  const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                  std::complex<double> *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hbmv", " for USM");
 }
 
 sycl::event hemv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
@@ -559,7 +559,7 @@ sycl::event hemv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t
                  const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                  std::complex<float> *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hemv", " for USM");
 }
 
 sycl::event hemv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
@@ -567,33 +567,33 @@ sycl::event hemv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t
                  const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                  std::complex<double> *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hemv", " for USM");
 }
 
 sycl::event her(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
                 const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
                 std::int64_t lda, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "her", " for USM");
 }
 
 sycl::event her(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
                 const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
                 std::int64_t lda, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "her", " for USM");
 }
 
 sycl::event her2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
                  std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                  const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                  std::int64_t lda, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "her2", " for USM");
 }
 
 sycl::event her2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
                  std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                  const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                  std::int64_t lda, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "her2", " for USM");
 }
 
 sycl::event hpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
@@ -601,7 +601,7 @@ sycl::event hpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t
                  const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
                  std::complex<float> *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hpmv", " for USM");
 }
 
 sycl::event hpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
@@ -609,276 +609,276 @@ sycl::event hpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t
                  const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
                  std::complex<double> *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hpmv", " for USM");
 }
 
 sycl::event hpr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
                 const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hpr", " for USM");
 }
 
 sycl::event hpr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
                 const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hpr", " for USM");
 }
 
 sycl::event hpr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
                  std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
                  const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hpr2", " for USM");
 }
 
 sycl::event hpr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
                  std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
                  const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hpr2", " for USM");
 }
 
 sycl::event sbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
                  float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
                  float beta, float *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "sbmv", " for USM");
 }
 
 sycl::event sbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
                  double alpha, const double *a, std::int64_t lda, const double *x,
                  std::int64_t incx, double beta, double *y, std::int64_t incy,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "sbmv", " for USM");
 }
 
 sycl::event symv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
                  const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta,
                  float *y, std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "symv", " for USM");
 }
 
 sycl::event symv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
                  const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta,
                  double *y, std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "symv", " for USM");
 }
 
 sycl::event syr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
                 const float *x, std::int64_t incx, float *a, std::int64_t lda,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syr", " for USM");
 }
 
 sycl::event syr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
                 const double *x, std::int64_t incx, double *a, std::int64_t lda,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syr", " for USM");
 }
 
 sycl::event syr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
                  const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
                  std::int64_t lda, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syr2", " for USM");
 }
 
 sycl::event syr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
                  const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
                  std::int64_t lda, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syr2", " for USM");
 }
 
 sycl::event spmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
                  const float *a, const float *x, std::int64_t incx, float beta, float *y,
                  std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "spmv", " for USM");
 }
 
 sycl::event spmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
                  const double *a, const double *x, std::int64_t incx, double beta, double *y,
                  std::int64_t incy, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "spmv", " for USM");
 }
 
 sycl::event spr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
                 const float *x, std::int64_t incx, float *a,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "spr", " for USM");
 }
 
 sycl::event spr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
                 const double *x, std::int64_t incx, double *a,
                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "spr", " for USM");
 }
 
 sycl::event spr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
                  const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "spr2", " for USM");
 }
 
 sycl::event spr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
                  const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "spr2", " for USM");
 }
 
 sycl::event tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                  std::int64_t lda, float *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbmv", " for USM");
 }
 
 sycl::event tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                  std::int64_t lda, double *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbmv", " for USM");
 }
 
 sycl::event tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
                  const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
                  std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbmv", " for USM");
 }
 
 sycl::event tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
                  const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
                  std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbmv", " for USM");
 }
 sycl::event tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
                  std::int64_t lda, float *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbsv", " for USM");
 }
 
 sycl::event tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
                  std::int64_t lda, double *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbsv", " for USM");
 }
 
 sycl::event tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
                  const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
                  std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbsv", " for USM");
 }
 
 sycl::event tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
                  const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
                  std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tbsv", " for USM");
 }
 
 sycl::event tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x,
                  std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpmv", " for USM");
 }
 
 sycl::event tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x,
                  std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpmv", " for USM");
 }
 
 sycl::event tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
                  std::complex<float> *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpmv", " for USM");
 }
 
 sycl::event tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
                  std::complex<double> *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpmv", " for USM");
 }
 
 sycl::event tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x,
                  std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpsv", " for USM");
 }
 
 sycl::event tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x,
                  std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpsv", " for USM");
 }
 
 sycl::event tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
                  std::complex<float> *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpsv", " for USM");
 }
 
 sycl::event tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
                  std::complex<double> *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "tpsv", " for USM");
 }
 
 sycl::event trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda,
                  float *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmv", " for USM");
 }
 
 sycl::event trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda,
                  double *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmv", " for USM");
 }
 
 sycl::event trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
                  std::int64_t lda, std::complex<float> *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmv", " for USM");
 }
 
 sycl::event trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
                  std::int64_t lda, std::complex<double> *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmv", " for USM");
 }
 
 sycl::event trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda,
                  float *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsv", " for USM");
 }
 
 sycl::event trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda,
                  double *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsv", " for USM");
 }
 
 sycl::event trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
                  std::int64_t lda, std::complex<float> *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsv", " for USM");
 }
 
 sycl::event trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
                  std::int64_t lda, std::complex<double> *x, std::int64_t incx,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsv", " for USM");
 }

--- a/src/blas/backends/syclblas/syclblas_level2.cxx
+++ b/src/blas/backends/syclblas/syclblas_level2.cxx
@@ -1,0 +1,884 @@
+/*******************************************************************************
+* Copyright Codeplay Software
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+// Buffer APIs
+
+void gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+          float alpha, sycl::buffer<float, 1> &a, std::int64_t lda, sycl::buffer<float, 1> &x,
+          std::int64_t incx, float beta, sycl::buffer<float, 1> &y, std::int64_t incy) {
+    CALL_SYCLBLAS_FN(::blas::_gemv, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+          double alpha, sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &x,
+          std::int64_t incx, double beta, sycl::buffer<double, 1> &y, std::int64_t incy) {
+    CALL_SYCLBLAS_FN(::blas::_gemv, queue, trans, m, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+          std::int64_t kl, std::int64_t ku, float alpha, sycl::buffer<float, 1> &a,
+          std::int64_t lda, sycl::buffer<float, 1> &x, std::int64_t incx, float beta,
+          sycl::buffer<float, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+          std::int64_t kl, std::int64_t ku, double alpha, sycl::buffer<double, 1> &a,
+          std::int64_t lda, sycl::buffer<double, 1> &x, std::int64_t incx, double beta,
+          sycl::buffer<double, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+          std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+          std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void ger(sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha, sycl::buffer<float, 1> &x,
+         std::int64_t incx, sycl::buffer<float, 1> &y, std::int64_t incy, sycl::buffer<float, 1> &a,
+         std::int64_t lda) {
+    CALL_SYCLBLAS_FN(::blas::_ger, queue, m, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void ger(sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha,
+         sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &y,
+         std::int64_t incy, sycl::buffer<double, 1> &a, std::int64_t lda) {
+    CALL_SYCLBLAS_FN(::blas::_ger, queue, m, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void gerc(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gerc(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void geru(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void geru(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void hbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void hbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void hemv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void hemv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void her(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+         sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+         sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void her(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+         sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+         sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+void her2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void her2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void hpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void hpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void hpr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+         sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+         sycl::buffer<std::complex<float>, 1> &a) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void hpr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+         sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+         sycl::buffer<std::complex<double>, 1> &a) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void hpr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<float>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<float>, 1> &a) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void hpr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx,
+          sycl::buffer<std::complex<double>, 1> &y, std::int64_t incy,
+          sycl::buffer<std::complex<double>, 1> &a) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void sbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
+          float alpha, sycl::buffer<float, 1> &a, std::int64_t lda, sycl::buffer<float, 1> &x,
+          std::int64_t incx, float beta, sycl::buffer<float, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void sbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
+          double alpha, sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &x,
+          std::int64_t incx, double beta, sycl::buffer<double, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void symv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+          sycl::buffer<float, 1> &a, std::int64_t lda, sycl::buffer<float, 1> &x, std::int64_t incx,
+          float beta, sycl::buffer<float, 1> &y, std::int64_t incy) {
+    CALL_SYCLBLAS_FN(::blas::_symv, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void symv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+          sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &x,
+          std::int64_t incx, double beta, sycl::buffer<double, 1> &y, std::int64_t incy) {
+    CALL_SYCLBLAS_FN(::blas::_symv, queue, upper_lower, n, alpha, a, lda, x, incx, beta, y, incy);
+}
+
+void syr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+         sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &a,
+         std::int64_t lda) {
+    CALL_SYCLBLAS_FN(::blas::_syr, queue, upper_lower, n, alpha, x, incx, a, lda);
+}
+
+void syr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+         sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &a,
+         std::int64_t lda) {
+    CALL_SYCLBLAS_FN(::blas::_syr, queue, upper_lower, n, alpha, x, incx, a, lda);
+}
+
+void syr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+          sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &y,
+          std::int64_t incy, sycl::buffer<float, 1> &a, std::int64_t lda) {
+    CALL_SYCLBLAS_FN(::blas::_syr2, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void syr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+          sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &y,
+          std::int64_t incy, sycl::buffer<double, 1> &a, std::int64_t lda) {
+    CALL_SYCLBLAS_FN(::blas::_syr2, queue, upper_lower, n, alpha, x, incx, y, incy, a, lda);
+}
+
+void spmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+          sycl::buffer<float, 1> &a, sycl::buffer<float, 1> &x, std::int64_t incx, float beta,
+          sycl::buffer<float, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void spmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+          sycl::buffer<double, 1> &a, sycl::buffer<double, 1> &x, std::int64_t incx, double beta,
+          sycl::buffer<double, 1> &y, std::int64_t incy) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void spr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+         sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &a) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void spr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+         sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &a) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void spr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+          sycl::buffer<float, 1> &x, std::int64_t incx, sycl::buffer<float, 1> &y,
+          std::int64_t incy, sycl::buffer<float, 1> &a) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void spr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+          sycl::buffer<double, 1> &x, std::int64_t incx, sycl::buffer<double, 1> &y,
+          std::int64_t incy, sycl::buffer<double, 1> &a) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<float, 1> &a,
+          std::int64_t lda, sycl::buffer<float, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<double, 1> &a,
+          std::int64_t lda, sycl::buffer<double, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<float, 1> &a,
+          std::int64_t lda, sycl::buffer<float, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, sycl::buffer<double, 1> &a,
+          std::int64_t lda, sycl::buffer<double, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<float, 1> &a,
+          sycl::buffer<float, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<double, 1> &a,
+          sycl::buffer<double, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+void tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<float, 1> &a,
+          sycl::buffer<float, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<double, 1> &a,
+          sycl::buffer<double, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<float>, 1> &a,
+          sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<double>, 1> &a,
+          sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<float, 1> &a, std::int64_t lda,
+          sycl::buffer<float, 1> &x, std::int64_t incx) {
+    CALL_SYCLBLAS_FN(::blas::_trmv, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx);
+}
+
+void trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<double, 1> &a, std::int64_t lda,
+          sycl::buffer<double, 1> &x, std::int64_t incx) {
+    CALL_SYCLBLAS_FN(::blas::_trmv, queue, upper_lower, trans, unit_diag, n, a, lda, x, incx);
+}
+
+void trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<float>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<double>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+void trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<float, 1> &a, std::int64_t lda,
+          sycl::buffer<float, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<double, 1> &a, std::int64_t lda,
+          sycl::buffer<double, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<float>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<float>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          oneapi::mkl::diag unit_diag, std::int64_t n, sycl::buffer<std::complex<double>, 1> &a,
+          std::int64_t lda, sycl::buffer<std::complex<double>, 1> &x, std::int64_t incx) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+// USM APIs
+
+sycl::event gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                 float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
+                 float beta, float *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                 double alpha, const double *a, std::int64_t lda, const double *x,
+                 std::int64_t incx, double beta, double *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
+                 const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
+                 const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                 std::int64_t kl, std::int64_t ku, float alpha, const float *a, std::int64_t lda,
+                 const float *x, std::int64_t incx, float beta, float *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                 std::int64_t kl, std::int64_t ku, double alpha, const double *a, std::int64_t lda,
+                 const double *x, std::int64_t incx, double beta, double *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                 std::int64_t kl, std::int64_t ku, std::complex<float> alpha,
+                 const std::complex<float> *a, std::int64_t lda, const std::complex<float> *x,
+                 std::int64_t incx, std::complex<float> beta, std::complex<float> *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gbmv(sycl::queue &queue, oneapi::mkl::transpose trans, std::int64_t m, std::int64_t n,
+                 std::int64_t kl, std::int64_t ku, std::complex<double> alpha,
+                 const std::complex<double> *a, std::int64_t lda, const std::complex<double> *x,
+                 std::int64_t incx, std::complex<double> beta, std::complex<double> *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event ger(sycl::queue &queue, std::int64_t m, std::int64_t n, float alpha, const float *x,
+                std::int64_t incx, const float *y, std::int64_t incy, float *a, std::int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event ger(sycl::queue &queue, std::int64_t m, std::int64_t n, double alpha, const double *x,
+                std::int64_t incx, const double *y, std::int64_t incy, double *a, std::int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gerc(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
+                 std::int64_t incy, std::complex<float> *a, std::int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gerc(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
+                 std::int64_t incy, std::complex<double> *a, std::int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event geru(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *x, std::int64_t incx, const std::complex<float> *y,
+                 std::int64_t incy, std::complex<float> *a, std::int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event geru(sycl::queue &queue, std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *x, std::int64_t incx, const std::complex<double> *y,
+                 std::int64_t incy, std::complex<double> *a, std::int64_t lda,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event hbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
+                 std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
+                 const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event hbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
+                 std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
+                 const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event hemv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
+                 const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event hemv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
+                 const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event her(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+                const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
+                std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event her(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+                const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
+                std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event her2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
+                 const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
+                 std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event her2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
+                 const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
+                 std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event hpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *a,
+                 const std::complex<float> *x, std::int64_t incx, std::complex<float> beta,
+                 std::complex<float> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event hpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *a,
+                 const std::complex<double> *x, std::int64_t incx, std::complex<double> beta,
+                 std::complex<double> *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event hpr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+                const std::complex<float> *x, std::int64_t incx, std::complex<float> *a,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event hpr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+                const std::complex<double> *x, std::int64_t incx, std::complex<double> *a,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event hpr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+                 std::complex<float> alpha, const std::complex<float> *x, std::int64_t incx,
+                 const std::complex<float> *y, std::int64_t incy, std::complex<float> *a,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event hpr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n,
+                 std::complex<double> alpha, const std::complex<double> *x, std::int64_t incx,
+                 const std::complex<double> *y, std::int64_t incy, std::complex<double> *a,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event sbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
+                 float alpha, const float *a, std::int64_t lda, const float *x, std::int64_t incx,
+                 float beta, float *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event sbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, std::int64_t k,
+                 double alpha, const double *a, std::int64_t lda, const double *x,
+                 std::int64_t incx, double beta, double *y, std::int64_t incy,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event symv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+                 const float *a, std::int64_t lda, const float *x, std::int64_t incx, float beta,
+                 float *y, std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event symv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+                 const double *a, std::int64_t lda, const double *x, std::int64_t incx, double beta,
+                 double *y, std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+                const float *x, std::int64_t incx, float *a, std::int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+                const double *x, std::int64_t incx, double *a, std::int64_t lda,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+                 const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
+                 std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+                 const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
+                 std::int64_t lda, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event spmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+                 const float *a, const float *x, std::int64_t incx, float beta, float *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event spmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+                 const double *a, const double *x, std::int64_t incx, double beta, double *y,
+                 std::int64_t incy, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event spr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+                const float *x, std::int64_t incx, float *a,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event spr(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+                const double *x, std::int64_t incx, double *a,
+                const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event spr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, float alpha,
+                 const float *x, std::int64_t incx, const float *y, std::int64_t incy, float *a,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event spr2(sycl::queue &queue, oneapi::mkl::uplo upper_lower, std::int64_t n, double alpha,
+                 const double *x, std::int64_t incx, const double *y, std::int64_t incy, double *a,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
+                 std::int64_t lda, float *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
+                 std::int64_t lda, double *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
+                 const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tbmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
+                 const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+sycl::event tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const float *a,
+                 std::int64_t lda, float *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k, const double *a,
+                 std::int64_t lda, double *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
+                 const std::complex<float> *a, std::int64_t lda, std::complex<float> *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tbsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, std::int64_t k,
+                 const std::complex<double> *a, std::int64_t lda, std::complex<double> *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
+                 std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tpmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
+                 std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, float *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, double *x,
+                 std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
+                 std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event tpsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
+                 std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda,
+                 float *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda,
+                 double *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
+                 std::int64_t lda, std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trmv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
+                 std::int64_t lda, std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const float *a, std::int64_t lda,
+                 float *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const double *a, std::int64_t lda,
+                 double *x, std::int64_t incx, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<float> *a,
+                 std::int64_t lda, std::complex<float> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsv(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 oneapi::mkl::diag unit_diag, std::int64_t n, const std::complex<double> *a,
+                 std::int64_t lda, std::complex<double> *x, std::int64_t incx,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}

--- a/src/blas/backends/syclblas/syclblas_level3.cpp
+++ b/src/blas/backends/syclblas/syclblas_level3.cpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+* Copyright Codeplay Software
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
+#include "syclblas_common.hpp"
+#include "oneapi/mkl/exceptions.hpp"
+#include "oneapi/mkl/blas/detail/syclblas/onemkl_blas_syclblas.hpp"
+
+namespace oneapi {
+namespace mkl {
+namespace blas {
+namespace syclblas {
+namespace column_major {
+
+#define COLUMN_MAJOR
+constexpr bool is_column_major() {
+    return true;
+}
+#include "syclblas_level3.cxx"
+#undef COLUMN_MAJOR
+
+} // namespace column_major
+namespace row_major {
+
+#define ROW_MAJOR
+constexpr bool is_column_major() {
+    return false;
+}
+#include "syclblas_level3.cxx"
+#undef ROW_MAJOR
+
+} // namespace row_major
+} // namespace syclblas
+} // namespace blas
+} // namespace mkl
+} // namespace oneapi

--- a/src/blas/backends/syclblas/syclblas_level3.cxx
+++ b/src/blas/backends/syclblas/syclblas_level3.cxx
@@ -1,0 +1,644 @@
+/*******************************************************************************
+* Copyright Codeplay Software
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+// Buffer APIs
+
+void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1> &a,
+          std::int64_t lda, sycl::buffer<float, 1> &b, std::int64_t ldb, float beta,
+          sycl::buffer<float, 1> &c, std::int64_t ldc) {
+    CALL_SYCLBLAS_FN(::blas::_gemm, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                     ldc);
+}
+
+void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, double alpha, sycl::buffer<double, 1> &a,
+          std::int64_t lda, sycl::buffer<double, 1> &b, std::int64_t ldb, double beta,
+          sycl::buffer<double, 1> &c, std::int64_t ldc) {
+    CALL_SYCLBLAS_FN(::blas::_gemm, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                     ldc);
+}
+
+void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+          sycl::buffer<sycl::half, 1> &a, std::int64_t lda, sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, sycl::half beta, sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          sycl::buffer<sycl::half, 1> &a, std::int64_t lda, sycl::buffer<sycl::half, 1> &b,
+          std::int64_t ldb, float beta, sycl::buffer<float, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+          std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+          sycl::buffer<oneapi::mkl::bfloat16, 1> &a, std::int64_t lda,
+          sycl::buffer<oneapi::mkl::bfloat16, 1> &b, std::int64_t ldb, float beta,
+          sycl::buffer<float, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          std::int64_t m, std::int64_t n, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
+          sycl::buffer<float, 1> &b, std::int64_t ldb, float beta, sycl::buffer<float, 1> &c,
+          std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          std::int64_t m, std::int64_t n, double alpha, sycl::buffer<double, 1> &a,
+          std::int64_t lda, sycl::buffer<double, 1> &b, std::int64_t ldb, double beta,
+          sycl::buffer<double, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          std::int64_t m, std::int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          std::int64_t m, std::int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void hemm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          std::int64_t m, std::int64_t n, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void hemm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          std::int64_t m, std::int64_t n, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
+          float beta, sycl::buffer<float, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          std::int64_t n, std::int64_t k, double alpha, sycl::buffer<double, 1> &a,
+          std::int64_t lda, double beta, sycl::buffer<double, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          std::int64_t n, std::int64_t k, std::complex<float> alpha,
+          sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda, std::complex<float> beta,
+          sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          std::int64_t n, std::int64_t k, std::complex<double> alpha,
+          sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda, std::complex<double> beta,
+          sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void herk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          std::int64_t n, std::int64_t k, float alpha, sycl::buffer<std::complex<float>, 1> &a,
+          std::int64_t lda, float beta, sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void herk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+          std::int64_t n, std::int64_t k, double alpha, sycl::buffer<std::complex<double>, 1> &a,
+          std::int64_t lda, double beta, sycl::buffer<std::complex<double>, 1> &c,
+          std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+           std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
+           sycl::buffer<float, 1> &b, std::int64_t ldb, float beta, sycl::buffer<float, 1> &c,
+           std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+           std::int64_t n, std::int64_t k, double alpha, sycl::buffer<double, 1> &a,
+           std::int64_t lda, sycl::buffer<double, 1> &b, std::int64_t ldb, double beta,
+           sycl::buffer<double, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+           std::int64_t n, std::int64_t k, std::complex<float> alpha,
+           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+           sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
+           sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+           std::int64_t n, std::int64_t k, std::complex<double> alpha,
+           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+           sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void her2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+           std::int64_t n, std::int64_t k, std::complex<float> alpha,
+           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+           sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, float beta,
+           sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void her2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+           std::int64_t n, std::int64_t k, std::complex<double> alpha,
+           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+           sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, double beta,
+           sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+          float alpha, sycl::buffer<float, 1> &a, std::int64_t lda, sycl::buffer<float, 1> &b,
+          std::int64_t ldb) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+          double alpha, sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &b,
+          std::int64_t ldb) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+          float alpha, sycl::buffer<float, 1> &a, std::int64_t lda, sycl::buffer<float, 1> &b,
+          std::int64_t ldb) {
+    CALL_SYCLBLAS_FN(::blas::_trsm, queue, left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                     a, lda, b, ldb);
+}
+
+void trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+          double alpha, sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &b,
+          std::int64_t ldb) {
+    CALL_SYCLBLAS_FN(::blas::_trsm, queue, left_right, upper_lower, trans, unit_diag, m, n, alpha,
+                     a, lda, b, ldb);
+}
+
+void trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+          std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+          oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
+          std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+          sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
+           oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, float alpha,
+           sycl::buffer<float, 1> &a, std::int64_t lda, sycl::buffer<float, 1> &b, std::int64_t ldb,
+           float beta, sycl::buffer<float, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
+           oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, double alpha,
+           sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &b,
+           std::int64_t ldb, double beta, sycl::buffer<double, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
+           oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, std::complex<float> alpha,
+           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
+           sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
+           sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
+           oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k,
+           std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
+           sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
+           sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+               oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k,
+               float alpha, sycl::buffer<int8_t, 1> &a, std::int64_t lda, int8_t ao,
+               sycl::buffer<uint8_t, 1> &b, std::int64_t ldb, uint8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, std::int64_t ldc, sycl::buffer<int32_t, 1> &co) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+               oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k,
+               float alpha, sycl::buffer<int8_t, 1> &a, std::int64_t lda, int8_t ao,
+               sycl::buffer<int8_t, 1> &b, std::int64_t ldb, int8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, std::int64_t ldc, sycl::buffer<int32_t, 1> &co) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+               oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k,
+               float alpha, sycl::buffer<uint8_t, 1> &a, std::int64_t lda, uint8_t ao,
+               sycl::buffer<int8_t, 1> &b, std::int64_t ldb, int8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, std::int64_t ldc, sycl::buffer<int32_t, 1> &co) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+void gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+               oneapi::mkl::offset offsetc, std::int64_t m, std::int64_t n, std::int64_t k,
+               float alpha, sycl::buffer<uint8_t, 1> &a, std::int64_t lda, uint8_t ao,
+               sycl::buffer<uint8_t, 1> &b, std::int64_t ldb, uint8_t bo, float beta,
+               sycl::buffer<int32_t, 1> &c, std::int64_t ldc, sycl::buffer<int32_t, 1> &co) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+// USM APIs
+
+sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
+                 std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
+                 std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                 const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
+                 std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                 const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
+                 std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
+                 const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
+                 sycl::half beta, sycl::half *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const sycl::half *a,
+                 std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta, float *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
+                 std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
+                 const oneapi::mkl::bfloat16 *a, std::int64_t lda, const oneapi::mkl::bfloat16 *b,
+                 std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
+                 const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
+                 const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
+                 std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
+                 std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event hemm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 std::int64_t m, std::int64_t n, std::complex<float> alpha,
+                 const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
+                 std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event hemm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 std::int64_t m, std::int64_t n, std::complex<double> alpha,
+                 const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
+                 std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
+                 std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
+                 float beta, float *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
+                 double beta, double *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                 const std::complex<float> *a, std::int64_t lda, std::complex<float> beta,
+                 std::complex<float> *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                 const std::complex<double> *a, std::int64_t lda, std::complex<double> beta,
+                 std::complex<double> *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event herk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a,
+                 std::int64_t lda, float beta, std::complex<float> *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event herk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                 std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a,
+                 std::int64_t lda, double beta, std::complex<double> *c, std::int64_t ldc,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                  std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
+                  const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                  std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
+                  const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                  std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                  const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
+                  std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
+                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                  std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                  const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
+                  std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
+                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event her2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                  std::int64_t n, std::int64_t k, std::complex<float> alpha,
+                  const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
+                  std::int64_t ldb, float beta, std::complex<float> *c, std::int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event her2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
+                  std::int64_t n, std::int64_t k, std::complex<double> alpha,
+                  const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
+                  std::int64_t ldb, double beta, std::complex<double> *c, std::int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
+                 std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
+                 std::int64_t ldb, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
+                 std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
+                 std::int64_t ldb, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
+                 std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
+                 std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
+                 std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
+                 std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
+                 std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
+                 std::int64_t ldb, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
+                 std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
+                 std::int64_t ldb, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
+                 std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
+                 std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
+                 oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
+                 std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
+                 std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
+                 const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
+                  oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, float alpha,
+                  const float *a, std::int64_t lda, const float *b, std::int64_t ldb, float beta,
+                  float *c, std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
+                  oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, double alpha,
+                  const double *a, std::int64_t lda, const double *b, std::int64_t ldb, double beta,
+                  double *c, std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
+                  oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k,
+                  std::complex<float> alpha, const std::complex<float> *a, std::int64_t lda,
+                  const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
+                  std::complex<float> *c, std::int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
+                  oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k,
+                  std::complex<double> alpha, const std::complex<double> *a, std::int64_t lda,
+                  const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
+                  std::complex<double> *c, std::int64_t ldc,
+                  const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa,
+                      oneapi::mkl::transpose transb, oneapi::mkl::offset offsetc, std::int64_t m,
+                      std::int64_t n, std::int64_t k, float alpha, const std::int8_t *a,
+                      std::int64_t lda, std::int8_t ao, const std::uint8_t *b, std::int64_t ldb,
+                      std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
+                      const std::int32_t *co, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa,
+                      oneapi::mkl::transpose transb, oneapi::mkl::offset offsetc, std::int64_t m,
+                      std::int64_t n, std::int64_t k, float alpha, const std::int8_t *a,
+                      std::int64_t lda, std::int8_t ao, const std::int8_t *b, std::int64_t ldb,
+                      std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
+                      const std::int32_t *co, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa,
+                      oneapi::mkl::transpose transb, oneapi::mkl::offset offsetc, std::int64_t m,
+                      std::int64_t n, std::int64_t k, float alpha, const std::uint8_t *a,
+                      std::int64_t lda, std::uint8_t ao, const std::int8_t *b, std::int64_t ldb,
+                      std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
+                      const std::int32_t *co, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}
+
+sycl::event gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa,
+                      oneapi::mkl::transpose transb, oneapi::mkl::offset offsetc, std::int64_t m,
+                      std::int64_t n, std::int64_t k, float alpha, const std::uint8_t *a,
+                      std::int64_t lda, std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb,
+                      std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
+                      const std::int32_t *co, const std::vector<sycl::event> &dependencies) {
+    throw std::runtime_error("Not implemented for syclblas");
+}

--- a/src/blas/backends/syclblas/syclblas_level3.cxx
+++ b/src/blas/backends/syclblas/syclblas_level3.cxx
@@ -40,7 +40,7 @@ void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transp
           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
           sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm", " for complex");
 }
 
 void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -48,21 +48,22 @@ void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transp
           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
           sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm", " for complex");
 }
 
 void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
           std::int64_t m, std::int64_t n, std::int64_t k, sycl::half alpha,
           sycl::buffer<sycl::half, 1> &a, std::int64_t lda, sycl::buffer<sycl::half, 1> &b,
           std::int64_t ldb, sycl::half beta, sycl::buffer<sycl::half, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    CALL_SYCLBLAS_FN(::blas::_gemm, queue, transa, transb, m, n, k, alpha, a, lda, b, ldb, beta, c,
+                     ldc);
 }
 
 void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
           std::int64_t m, std::int64_t n, std::int64_t k, float alpha,
           sycl::buffer<sycl::half, 1> &a, std::int64_t lda, sycl::buffer<sycl::half, 1> &b,
           std::int64_t ldb, float beta, sycl::buffer<float, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm", " for different argument data types");
 }
 
 void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -70,21 +71,21 @@ void gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transp
           sycl::buffer<oneapi::mkl::bfloat16, 1> &a, std::int64_t lda,
           sycl::buffer<oneapi::mkl::bfloat16, 1> &b, std::int64_t ldb, float beta,
           sycl::buffer<float, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm", " for bfloat16");
 }
 
 void symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
           std::int64_t m, std::int64_t n, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
           sycl::buffer<float, 1> &b, std::int64_t ldb, float beta, sycl::buffer<float, 1> &c,
           std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "symm", "");
 }
 
 void symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
           std::int64_t m, std::int64_t n, double alpha, sycl::buffer<double, 1> &a,
           std::int64_t lda, sycl::buffer<double, 1> &b, std::int64_t ldb, double beta,
           sycl::buffer<double, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "symm", "");
 }
 
 void symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -92,7 +93,7 @@ void symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo up
           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
           sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "symm", "");
 }
 
 void symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -100,7 +101,7 @@ void symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo up
           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
           sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "symm", "");
 }
 
 void hemm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -108,7 +109,7 @@ void hemm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo up
           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
           sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hemm", "");
 }
 
 void hemm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -116,60 +117,60 @@ void hemm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo up
           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
           sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hemm", "");
 }
 
 void syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
           float beta, sycl::buffer<float, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk", "");
 }
 
 void syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           std::int64_t n, std::int64_t k, double alpha, sycl::buffer<double, 1> &a,
           std::int64_t lda, double beta, sycl::buffer<double, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk", "");
 }
 
 void syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           std::int64_t n, std::int64_t k, std::complex<float> alpha,
           sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda, std::complex<float> beta,
           sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk", "");
 }
 
 void syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           std::int64_t n, std::int64_t k, std::complex<double> alpha,
           sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda, std::complex<double> beta,
           sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk", "");
 }
 
 void herk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           std::int64_t n, std::int64_t k, float alpha, sycl::buffer<std::complex<float>, 1> &a,
           std::int64_t lda, float beta, sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "herk", "");
 }
 
 void herk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
           std::int64_t n, std::int64_t k, double alpha, sycl::buffer<std::complex<double>, 1> &a,
           std::int64_t lda, double beta, sycl::buffer<std::complex<double>, 1> &c,
           std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "herk", "");
 }
 
 void syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
            std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1> &a, std::int64_t lda,
            sycl::buffer<float, 1> &b, std::int64_t ldb, float beta, sycl::buffer<float, 1> &c,
            std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syr2k", "");
 }
 
 void syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
            std::int64_t n, std::int64_t k, double alpha, sycl::buffer<double, 1> &a,
            std::int64_t lda, sycl::buffer<double, 1> &b, std::int64_t ldb, double beta,
            sycl::buffer<double, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syr2k", "");
 }
 
 void syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -177,7 +178,7 @@ void syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::trans
            sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
            sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
            sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syr2k", "");
 }
 
 void syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -185,7 +186,7 @@ void syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::trans
            sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
            sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
            sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syr2k", "");
 }
 
 void her2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -193,7 +194,7 @@ void her2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::trans
            sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
            sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, float beta,
            sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "her2k", "");
 }
 
 void her2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -201,35 +202,35 @@ void her2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::trans
            sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
            sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, double beta,
            sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "her2k", "");
 }
 
 void trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
           oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
           float alpha, sycl::buffer<float, 1> &a, std::int64_t lda, sycl::buffer<float, 1> &b,
           std::int64_t ldb) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmm", "");
 }
 
 void trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
           oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
           double alpha, sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &b,
           std::int64_t ldb) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmm", "");
 }
 
 void trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
           oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
           std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmm", "");
 }
 
 void trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
           oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
           std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmm", "");
 }
 
 void trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -252,28 +253,28 @@ void trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo up
           oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
           std::complex<float> alpha, sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm", " for complex");
 }
 
 void trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
           oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m, std::int64_t n,
           std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
           sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm", " for complex");
 }
 
 void gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
            oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, float alpha,
            sycl::buffer<float, 1> &a, std::int64_t lda, sycl::buffer<float, 1> &b, std::int64_t ldb,
            float beta, sycl::buffer<float, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemmt", "");
 }
 
 void gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
            oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, double alpha,
            sycl::buffer<double, 1> &a, std::int64_t lda, sycl::buffer<double, 1> &b,
            std::int64_t ldb, double beta, sycl::buffer<double, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemmt", "");
 }
 
 void gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
@@ -281,7 +282,7 @@ void gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::trans
            sycl::buffer<std::complex<float>, 1> &a, std::int64_t lda,
            sycl::buffer<std::complex<float>, 1> &b, std::int64_t ldb, std::complex<float> beta,
            sycl::buffer<std::complex<float>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemmt", "");
 }
 
 void gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
@@ -289,7 +290,7 @@ void gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::trans
            std::complex<double> alpha, sycl::buffer<std::complex<double>, 1> &a, std::int64_t lda,
            sycl::buffer<std::complex<double>, 1> &b, std::int64_t ldb, std::complex<double> beta,
            sycl::buffer<std::complex<double>, 1> &c, std::int64_t ldc) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemmt", "");
 }
 
 void gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -297,7 +298,7 @@ void gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::t
                float alpha, sycl::buffer<int8_t, 1> &a, std::int64_t lda, int8_t ao,
                sycl::buffer<uint8_t, 1> &b, std::int64_t ldb, uint8_t bo, float beta,
                sycl::buffer<int32_t, 1> &c, std::int64_t ldc, sycl::buffer<int32_t, 1> &co) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_bias", "");
 }
 
 void gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -305,7 +306,7 @@ void gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::t
                float alpha, sycl::buffer<int8_t, 1> &a, std::int64_t lda, int8_t ao,
                sycl::buffer<int8_t, 1> &b, std::int64_t ldb, int8_t bo, float beta,
                sycl::buffer<int32_t, 1> &c, std::int64_t ldc, sycl::buffer<int32_t, 1> &co) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_bias", "");
 }
 
 void gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -313,7 +314,7 @@ void gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::t
                float alpha, sycl::buffer<uint8_t, 1> &a, std::int64_t lda, uint8_t ao,
                sycl::buffer<int8_t, 1> &b, std::int64_t ldb, int8_t bo, float beta,
                sycl::buffer<int32_t, 1> &c, std::int64_t ldc, sycl::buffer<int32_t, 1> &co) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_bias", "");
 }
 
 void gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -321,7 +322,7 @@ void gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::t
                float alpha, sycl::buffer<uint8_t, 1> &a, std::int64_t lda, uint8_t ao,
                sycl::buffer<uint8_t, 1> &b, std::int64_t ldb, uint8_t bo, float beta,
                sycl::buffer<int32_t, 1> &c, std::int64_t ldc, sycl::buffer<int32_t, 1> &co) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_bias", "");
 }
 
 // USM APIs
@@ -330,14 +331,14 @@ sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl:
                  std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const float *a,
                  std::int64_t lda, const float *b, std::int64_t ldb, float beta, float *c,
                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm", " for USM");
 }
 
 sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
                  std::int64_t m, std::int64_t n, std::int64_t k, double alpha, const double *a,
                  std::int64_t lda, const double *b, std::int64_t ldb, double beta, double *c,
                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm", " for USM");
 }
 
 sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -345,7 +346,7 @@ sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl:
                  const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                  std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm", " for USM");
 }
 
 sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -353,7 +354,7 @@ sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl:
                  const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                  std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm", " for USM");
 }
 
 sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -361,14 +362,14 @@ sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl:
                  const sycl::half *a, std::int64_t lda, const sycl::half *b, std::int64_t ldb,
                  sycl::half beta, sycl::half *c, std::int64_t ldc,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm", " for USM");
 }
 
 sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
                  std::int64_t m, std::int64_t n, std::int64_t k, float alpha, const sycl::half *a,
                  std::int64_t lda, const sycl::half *b, std::int64_t ldb, float beta, float *c,
                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm", " for USM");
 }
 
 sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl::transpose transb,
@@ -376,21 +377,21 @@ sycl::event gemm(sycl::queue &queue, oneapi::mkl::transpose transa, oneapi::mkl:
                  const oneapi::mkl::bfloat16 *a, std::int64_t lda, const oneapi::mkl::bfloat16 *b,
                  std::int64_t ldb, float beta, float *c, std::int64_t ldc,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm", " for USM");
 }
 
 sycl::event symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
                  std::int64_t m, std::int64_t n, float alpha, const float *a, std::int64_t lda,
                  const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "symm", " for USM");
 }
 
 sycl::event symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
                  std::int64_t m, std::int64_t n, double alpha, const double *a, std::int64_t lda,
                  const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "symm", " for USM");
 }
 
 sycl::event symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -398,7 +399,7 @@ sycl::event symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::
                  const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                  std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "symm", " for USM");
 }
 
 sycl::event symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -406,7 +407,7 @@ sycl::event symm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::
                  const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                  std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "symm", " for USM");
 }
 
 sycl::event hemm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -414,7 +415,7 @@ sycl::event hemm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::
                  const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                  std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hemm", " for USM");
 }
 
 sycl::event hemm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -422,21 +423,21 @@ sycl::event hemm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::
                  const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                  std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                  std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "hemm", " for USM");
 }
 
 sycl::event syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                  float beta, float *c, std::int64_t ldc,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk", " for USM");
 }
 
 sycl::event syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
                  double beta, double *c, std::int64_t ldc,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk", " for USM");
 }
 
 sycl::event syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -444,7 +445,7 @@ sycl::event syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl:
                  const std::complex<float> *a, std::int64_t lda, std::complex<float> beta,
                  std::complex<float> *c, std::int64_t ldc,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk", " for USM");
 }
 
 sycl::event syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -452,35 +453,35 @@ sycl::event syrk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl:
                  const std::complex<double> *a, std::int64_t lda, std::complex<double> beta,
                  std::complex<double> *c, std::int64_t ldc,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syrk", " for USM");
 }
 
 sycl::event herk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  std::int64_t n, std::int64_t k, float alpha, const std::complex<float> *a,
                  std::int64_t lda, float beta, std::complex<float> *c, std::int64_t ldc,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "herk", " for USM");
 }
 
 sycl::event herk(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                  std::int64_t n, std::int64_t k, double alpha, const std::complex<double> *a,
                  std::int64_t lda, double beta, std::complex<double> *c, std::int64_t ldc,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "herk", " for USM");
 }
 
 sycl::event syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                   std::int64_t n, std::int64_t k, float alpha, const float *a, std::int64_t lda,
                   const float *b, std::int64_t ldb, float beta, float *c, std::int64_t ldc,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syr2k", " for USM");
 }
 
 sycl::event syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
                   std::int64_t n, std::int64_t k, double alpha, const double *a, std::int64_t lda,
                   const double *b, std::int64_t ldb, double beta, double *c, std::int64_t ldc,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syr2k", " for USM");
 }
 
 sycl::event syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -488,7 +489,7 @@ sycl::event syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl
                   const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                   std::int64_t ldb, std::complex<float> beta, std::complex<float> *c,
                   std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syr2k", " for USM");
 }
 
 sycl::event syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -496,7 +497,7 @@ sycl::event syr2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl
                   const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                   std::int64_t ldb, std::complex<double> beta, std::complex<double> *c,
                   std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "syr2k", " for USM");
 }
 
 sycl::event her2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -504,7 +505,7 @@ sycl::event her2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl
                   const std::complex<float> *a, std::int64_t lda, const std::complex<float> *b,
                   std::int64_t ldb, float beta, std::complex<float> *c, std::int64_t ldc,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "her2k", " for USM");
 }
 
 sycl::event her2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose trans,
@@ -512,21 +513,21 @@ sycl::event her2k(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl
                   const std::complex<double> *a, std::int64_t lda, const std::complex<double> *b,
                   std::int64_t ldb, double beta, std::complex<double> *c, std::int64_t ldc,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "her2k", " for USM");
 }
 
 sycl::event trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
                  oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
                  std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
                  std::int64_t ldb, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmm", " for USM");
 }
 
 sycl::event trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
                  oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
                  std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
                  std::int64_t ldb, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmm", " for USM");
 }
 
 sycl::event trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -534,7 +535,7 @@ sycl::event trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::
                  std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                  std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmm", " for USM");
 }
 
 sycl::event trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -542,21 +543,21 @@ sycl::event trmm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::
                  std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                  std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trmm", " for USM");
 }
 
 sycl::event trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
                  oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
                  std::int64_t n, float alpha, const float *a, std::int64_t lda, float *b,
                  std::int64_t ldb, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm", " for USM");
 }
 
 sycl::event trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
                  oneapi::mkl::transpose trans, oneapi::mkl::diag unit_diag, std::int64_t m,
                  std::int64_t n, double alpha, const double *a, std::int64_t lda, double *b,
                  std::int64_t ldb, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm", " for USM");
 }
 
 sycl::event trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -564,7 +565,7 @@ sycl::event trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::
                  std::int64_t n, std::complex<float> alpha, const std::complex<float> *a,
                  std::int64_t lda, std::complex<float> *b, std::int64_t ldb,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm", " for USM");
 }
 
 sycl::event trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::uplo upper_lower,
@@ -572,21 +573,21 @@ sycl::event trsm(sycl::queue &queue, oneapi::mkl::side left_right, oneapi::mkl::
                  std::int64_t n, std::complex<double> alpha, const std::complex<double> *a,
                  std::int64_t lda, std::complex<double> *b, std::int64_t ldb,
                  const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "trsm", " for USM");
 }
 
 sycl::event gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
                   oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, float alpha,
                   const float *a, std::int64_t lda, const float *b, std::int64_t ldb, float beta,
                   float *c, std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemmt", " for USM");
 }
 
 sycl::event gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
                   oneapi::mkl::transpose transb, std::int64_t n, std::int64_t k, double alpha,
                   const double *a, std::int64_t lda, const double *b, std::int64_t ldb, double beta,
                   double *c, std::int64_t ldc, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemmt", " for USM");
 }
 
 sycl::event gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
@@ -595,7 +596,7 @@ sycl::event gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl
                   const std::complex<float> *b, std::int64_t ldb, std::complex<float> beta,
                   std::complex<float> *c, std::int64_t ldc,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemmt", " for USM");
 }
 
 sycl::event gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl::transpose transa,
@@ -604,7 +605,7 @@ sycl::event gemmt(sycl::queue &queue, oneapi::mkl::uplo upper_lower, oneapi::mkl
                   const std::complex<double> *b, std::int64_t ldb, std::complex<double> beta,
                   std::complex<double> *c, std::int64_t ldc,
                   const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemmt", " for USM");
 }
 
 sycl::event gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -613,7 +614,7 @@ sycl::event gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa,
                       std::int64_t lda, std::int8_t ao, const std::uint8_t *b, std::int64_t ldb,
                       std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
                       const std::int32_t *co, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_bias", " for USM");
 }
 
 sycl::event gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -622,7 +623,7 @@ sycl::event gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa,
                       std::int64_t lda, std::int8_t ao, const std::int8_t *b, std::int64_t ldb,
                       std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
                       const std::int32_t *co, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_bias", " for USM");
 }
 
 sycl::event gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -631,7 +632,7 @@ sycl::event gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa,
                       std::int64_t lda, std::uint8_t ao, const std::int8_t *b, std::int64_t ldb,
                       std::int8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
                       const std::int32_t *co, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_bias", " for USM");
 }
 
 sycl::event gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa,
@@ -640,5 +641,5 @@ sycl::event gemm_bias(sycl::queue &queue, oneapi::mkl::transpose transa,
                       std::int64_t lda, std::uint8_t ao, const std::uint8_t *b, std::int64_t ldb,
                       std::uint8_t bo, float beta, std::int32_t *c, std::int64_t ldc,
                       const std::int32_t *co, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for syclblas");
+    throw unimplemented("blas", "gemm_bias", " for USM");
 }

--- a/src/blas/backends/syclblas/syclblas_wrappers.cpp
+++ b/src/blas/backends/syclblas/syclblas_wrappers.cpp
@@ -1,0 +1,21 @@
+//
+// generated file
+//
+
+#include "blas/function_table.hpp"
+
+#include "oneapi/mkl/blas/detail/syclblas/onemkl_blas_syclblas.hpp"
+
+#define WRAPPER_VERSION 1
+
+extern "C" ONEMKL_EXPORT blas_function_table_t mkl_blas_table = {
+    WRAPPER_VERSION,
+#define BACKEND syclblas
+#define MAJOR   column_major
+#include "../backend_wrappers.cxx"
+#undef MAJOR
+#define MAJOR row_major
+#include "../backend_wrappers.cxx"
+#undef MAJOR
+#undef BACKEND
+};

--- a/src/config.hpp.in
+++ b/src/config.hpp.in
@@ -28,6 +28,7 @@
 #cmakedefine ENABLE_MKLCPU_BACKEND
 #cmakedefine ENABLE_MKLGPU_BACKEND
 #cmakedefine ENABLE_NETLIB_BACKEND
+#cmakedefine ENABLE_SYCLBLAS_BACKEND
 #cmakedefine BUILD_SHARED_LIBS
 
 #endif

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -118,6 +118,11 @@ foreach(domain ${TARGET_DOMAINS})
     list(APPEND ONEMKL_LIBRARIES_${domain} onemkl_${domain}_netlib)
   endif()
 
+  if(domain STREQUAL "blas" AND ENABLE_SYCLBLAS_BACKEND)
+    add_dependencies(test_main_${domain}_ct onemkl_${domain}_syclblas)
+    list(APPEND ONEMKL_LIBRARIES_${domain} onemkl_${domain}_syclblas)
+  endif()
+
   if(domain STREQUAL "lapack" AND ENABLE_CUSOLVER_BACKEND)
     add_dependencies(test_main_${domain}_ct onemkl_${domain}_cusolver)
     list(APPEND ONEMKL_LIBRARIES_${domain} onemkl_${domain}_cusolver)

--- a/tests/unit_tests/include/test_helper.hpp
+++ b/tests/unit_tests/include/test_helper.hpp
@@ -65,9 +65,14 @@
 #define TEST_RUN_INTELCPU_SELECT(q, func, ...)
 #endif
 
+#if defined(ENABLE_MKLGPU_BACKEND) || defined(ENABLE_SYCLBLAS_BACKEND)
 #ifdef ENABLE_MKLGPU_BACKEND
 #define TEST_RUN_INTELGPU_SELECT(q, func, ...) \
     func(oneapi::mkl::backend_selector<oneapi::mkl::backend::mklgpu>{ q }, __VA_ARGS__)
+#else
+#define TEST_RUN_INTELGPU_SELECT(q, func, ...) \
+    func(oneapi::mkl::backend_selector<oneapi::mkl::backend::syclblas>{ q }, __VA_ARGS__)
+#endif // ENABLE_MKLGPU_BACKEND
 #else
 #define TEST_RUN_INTELGPU_SELECT(q, func, ...)
 #endif

--- a/tests/unit_tests/main_test.cpp
+++ b/tests/unit_tests/main_test.cpp
@@ -112,7 +112,7 @@ int main(int argc, char** argv) {
                         if (dev.is_cpu())
                             continue;
 #endif
-#ifndef ENABLE_MKLGPU_BACKEND
+#if !defined(ENABLE_MKLGPU_BACKEND) && !defined(ENABLE_SYCLBLAS_BACKEND)
                         if (dev.is_gpu() && vendor_id == INTEL_ID)
                             continue;
 #endif


### PR DESCRIPTION
Initial work to integrate SYCL-BLAS as an open-source cross-vendor GPU BLAS implementation.

* Integration of column-major SYCL-BLAS buffer API.
* Targets github.com/codeplaysoftware/sycl-blas 80b3cd79a6db5d1dfca7895292bb137ab17daaee
* Includes:
  * Documenation
  * CMake
  * Wrappers

SYCL-BLAS passes unit tests where the API is implemented (ie. buffer column-major API for selected functions).
