### PR TITLE
[DFT] Extend descriptor.get/set_value for existing dft values

### DIFF
--- a/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
@@ -65,7 +65,7 @@ public:
     sycl::queue& get_queue() {
         return queue_;
     };
-    dft_values get_values() {
+    dft_values<prec, dom> get_values() {
         return values_;
     };
 
@@ -77,7 +77,7 @@ private:
     std::vector<std::int64_t> dimensions_;
 
     // descriptor configuration values_ and structs
-    dft_values values_;
+    dft_values<prec, dom> values_;
 };
 
 } // namespace detail

--- a/include/oneapi/mkl/dft/detail/types_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/types_impl.hpp
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <vector>
+#include <type_traits>
 
 namespace oneapi {
 namespace mkl {
@@ -63,6 +64,7 @@ enum class config_param {
     PACKED_FORMAT,
     COMMIT_STATUS
 };
+
 enum class config_value {
     // for config_param::COMMIT_STATUS
     COMMITTED,
@@ -92,24 +94,31 @@ enum class config_value {
     CCE_FORMAT
 };
 
-struct dft_values {
+template <precision prec, domain dom>
+class dft_values {
+private:
+    using real_t = std::conditional_t<prec == precision::SINGLE, float, double>;
+
+public:
     std::vector<std::int64_t> input_strides;
     std::vector<std::int64_t> output_strides;
-    double bwd_scale;
-    double fwd_scale;
+    real_t bwd_scale;
+    real_t fwd_scale;
     std::int64_t number_of_transforms;
     std::int64_t fwd_dist;
     std::int64_t bwd_dist;
     config_value placement;
     config_value complex_storage;
+    config_value real_storage;
     config_value conj_even_storage;
     config_value workspace;
-
+    config_value ordering;
+    bool transpose;
+    config_value packed_format;
     std::vector<std::int64_t> dimensions;
     std::int64_t rank;
-    domain domain;
-    precision precision;
 };
+
 } // namespace detail
 } // namespace dft
 } // namespace mkl

--- a/include/oneapi/mkl/dft/detail/types_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/types_impl.hpp
@@ -87,12 +87,9 @@ enum class config_value {
     ALLOW,
     AVOID,
     NONE,
-    WORKSPACE_INTERNAL,
-    WORKSPACE_EXTERNAL,
 
     // for config_param::PACKED_FORMAT for storing conjugate-even finite sequence in real containers
     CCE_FORMAT
-
 };
 
 struct dft_values {

--- a/include/oneapi/mkl/dft/types.hpp
+++ b/include/oneapi/mkl/dft/types.hpp
@@ -33,7 +33,6 @@ using precision = detail::precision;
 using domain = detail::domain;
 using config_param = detail::config_param;
 using config_value = detail::config_value;
-using dft_values = detail::dft_values;
 using DFT_ERROR = detail::DFT_ERROR;
 
 } // namespace dft

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -41,7 +41,7 @@ namespace mklcpu {
 template <precision prec, domain dom>
 class commit_derived_impl : public detail::commit_impl {
 public:
-    commit_derived_impl(sycl::queue queue, dft_values config_values)
+    commit_derived_impl(sycl::queue queue, detail::dft_values<prec, dom> config_values)
             : detail::commit_impl(queue),
               status(DFT_NOTSET) {
         if (config_values.rank == 1) {
@@ -102,7 +102,7 @@ private:
         return value_err;
     }
 
-    void set_value(DFTI_DESCRIPTOR_HANDLE& descHandle, dft_values config) {
+    void set_value(DFTI_DESCRIPTOR_HANDLE& descHandle, detail::dft_values<prec, dom> config) {
         set_value_item(descHandle, DFTI_INPUT_STRIDES, config.input_strides.data());
         set_value_item(descHandle, DFTI_OUTPUT_STRIDES, config.output_strides.data());
         set_value_item(descHandle, DFTI_BACKWARD_SCALE, config.bwd_scale);

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -58,7 +58,7 @@ private:
     using mklgpu_descriptor_t = dft::descriptor<mklgpu_prec, mklgpu_dom>;
 
 public:
-    commit_derived_impl(sycl::queue queue, dft::detail::dft_values config_values)
+    commit_derived_impl(sycl::queue queue, dft::detail::dft_values<prec, dom> config_values)
             : oneapi::mkl::dft::detail::commit_impl(queue),
               handle(config_values.dimensions) {
         set_value(handle, config_values);
@@ -84,7 +84,7 @@ private:
     // The native MKLGPU class.
     mklgpu_descriptor_t handle;
 
-    void set_value(mklgpu_descriptor_t& desc, dft::detail::dft_values config) {
+    void set_value(mklgpu_descriptor_t& desc, dft::detail::dft_values<prec, dom> config) {
         using onemkl_param = dft::detail::config_param;
         using backend_param = dft::config_param;
 
@@ -96,20 +96,29 @@ private:
         desc.set_value(backend_param::NUMBER_OF_TRANSFORMS, config.number_of_transforms);
         desc.set_value(backend_param::COMPLEX_STORAGE,
                        to_mklgpu<onemkl_param::COMPLEX_STORAGE>(config.complex_storage));
-        // desc.set_value(backend_param::REAL_STORAGE, to_mklgpu<onemkl_param::REAL_STORAGE>(config.real_storage));
-        // Conjugate even storage only supports COMPLEX_COMPLEX. to_mklgpu will throw on invalid config.
-        (void)to_mklgpu<onemkl_param::CONJUGATE_EVEN_STORAGE>(config.conj_even_storage);
+        if (config.real_storage != dft::detail::config_value::REAL_REAL) {
+            throw mkl::invalid_argument("DFT", "commit",
+                                        "MKLGPU only supports real-real real storage.");
+        }
+        desc.set_value(backend_param::CONJUGATE_EVEN_STORAGE,
+                       to_mklgpu<onemkl_param::CONJUGATE_EVEN_STORAGE>(config.conj_even_storage));
         desc.set_value(backend_param::PLACEMENT,
                        to_mklgpu<onemkl_param::PLACEMENT>(config.placement));
         desc.set_value(backend_param::INPUT_STRIDES, config.input_strides.data());
         desc.set_value(backend_param::OUTPUT_STRIDES, config.output_strides.data());
         desc.set_value(backend_param::FWD_DISTANCE, config.fwd_dist);
         desc.set_value(backend_param::BWD_DISTANCE, config.bwd_dist);
-        // Leave backend_param::REAL_STORAGE as default value (exists as config param, but no value ine dft_values)
-        // Leave backend_param::WORKSPACE as default value.
-        // Leave backend_param::ORDERING as default value.
-        // Leave backend_param::TRANSPOSE as false (default value).
-        // Leave backend_param::PACKED_FORMAT as only available value: CCE_FORMAT.
+        // Setting the workspace causes an FFT_INVALID_DESCRIPTOR.
+        // Setting the ordering causes an FFT_INVALID_DESCRIPTOR. Check that default is used:
+        if (config.ordering != dft::detail::config_value::ORDERED) {
+            throw mkl::invalid_argument("DFT", "commit", "MKLGPU only supports ordered ordering.");
+        }
+        // Setting the transpose causes an FFT_INVALID_DESCRIPTOR. Check that default is used:
+        if (config.transpose != false) {
+            throw mkl::invalid_argument("DFT", "commit", "MKLGPU only supports non-transposed.");
+        }
+        desc.set_value(backend_param::PACKED_FORMAT,
+                       to_mklgpu<onemkl_param::PACKED_FORMAT>(config.packed_format));
     }
 };
 } // namespace detail

--- a/src/dft/backends/mklgpu/mklgpu_helpers.hpp
+++ b/src/dft/backends/mklgpu/mklgpu_helpers.hpp
@@ -96,8 +96,8 @@ inline constexpr int to_mklgpu<dft::detail::config_param::COMPLEX_STORAGE>(
         return DFTI_COMPLEX_COMPLEX;
     }
     else {
-        throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
-                                    "MKLGPU only supports complex-complex for complex storage.");
+        throw mkl::unimplemented("dft", "MKLGPU descriptor set_value()",
+                                 "MKLGPU only supports complex-complex for complex storage.");
         return 0;
     }
 }

--- a/src/dft/backends/mklgpu/mklgpu_helpers.hpp
+++ b/src/dft/backends/mklgpu/mklgpu_helpers.hpp
@@ -95,12 +95,9 @@ inline constexpr int to_mklgpu<dft::detail::config_param::COMPLEX_STORAGE>(
     if (value == dft::detail::config_value::COMPLEX_COMPLEX) {
         return DFTI_COMPLEX_COMPLEX;
     }
-    else if (value == dft::detail::config_value::REAL_REAL) {
-        return DFTI_REAL_REAL;
-    }
     else {
         throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
-                                    "Invalid config value for complex storage.");
+                                    "MKLGPU only supports complex-complex for complex storage.");
         return 0;
     }
 }

--- a/src/dft/backends/mklgpu/mklgpu_helpers.hpp
+++ b/src/dft/backends/mklgpu/mklgpu_helpers.hpp
@@ -76,7 +76,8 @@ inline constexpr dft::config_param to_mklgpu(dft::detail::config_param param) {
         case iparam::PACKED_FORMAT: return oparam::PACKED_FORMAT;
         case iparam::COMMIT_STATUS: return oparam::COMMIT_STATUS;
         default:
-            mkl::invalid_argument("dft", "MKLGPU descriptor set_value()", "Invalid config param.");
+            throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                                        "Invalid config param.");
             return static_cast<oparam>(0);
     }
 }
@@ -95,11 +96,11 @@ inline constexpr int to_mklgpu<dft::detail::config_param::COMPLEX_STORAGE>(
         return DFTI_COMPLEX_COMPLEX;
     }
     else if (value == dft::detail::config_value::REAL_REAL) {
-        return DFTI_COMPLEX_REAL;
+        return DFTI_REAL_REAL;
     }
     else {
-        mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
-                              "Invalid config value for complex storage.");
+        throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                                    "Invalid config value for complex storage.");
         return 0;
     }
 }
@@ -111,8 +112,8 @@ inline constexpr int to_mklgpu<dft::detail::config_param::CONJUGATE_EVEN_STORAGE
         return DFTI_COMPLEX_COMPLEX;
     }
     else {
-        mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
-                              "Invalid config value for conjugate even storage.");
+        throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                                    "Invalid config value for conjugate even storage.");
         return 0;
     }
 }
@@ -127,12 +128,24 @@ inline constexpr int to_mklgpu<dft::detail::config_param::PLACEMENT>(
         return DFTI_NOT_INPLACE;
     }
     else {
-        mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
-                              "Invalid config value for inplace.");
+        throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                                    "Invalid config value for inplace.");
         return 0;
     }
 }
 
+template <>
+inline constexpr int to_mklgpu<dft::detail::config_param::PACKED_FORMAT>(
+    dft::detail::config_value value) {
+    if (value == dft::detail::config_value::CCE_FORMAT) {
+        return DFTI_CCE_FORMAT;
+    }
+    else {
+        throw mkl::invalid_argument("dft", "MKLGPU descriptor set_value()",
+                                    "Invalid config value for packed format.");
+        return 0;
+    }
+}
 } // namespace detail
 } // namespace mklgpu
 } // namespace dft

--- a/src/dft/descriptor.cxx
+++ b/src/dft/descriptor.cxx
@@ -133,7 +133,7 @@ descriptor<prec, dom>::descriptor(std::vector<std::int64_t> dimensions)
     std::vector<std::int64_t> strides(rank_ + 1, 1);
     // The first variable stide value is different.
     if (rank_ > 1) {
-        strides[rank_ - 1] = dimensions_[rank_] / 2 + 1;
+        strides[rank_ - 1] = dimensions_[rank_ - 1] / 2 + 1;
     }
     for (int i = rank_ - 2; i > 0; --i) {
         strides[i] = strides[i + 1] * dimensions_[i];
@@ -141,7 +141,7 @@ descriptor<prec, dom>::descriptor(std::vector<std::int64_t> dimensions)
     strides[0] = 0;
     // Default for correct strides for forward transform.
     values_.output_strides = strides;
-    if constexpr (dom == domain::COMPLEX) {
+    if constexpr (dom == domain::REAL) {
         for (int i = 1; i < rank_; ++i) {
             strides[i] *= 2;
         }

--- a/src/dft/descriptor.cxx
+++ b/src/dft/descriptor.cxx
@@ -46,6 +46,9 @@ void descriptor<prec, dom>::set_value(config_param param, ...) {
             }
             else {
                 auto ptr = va_arg(vl, std::int64_t*);
+                if (ptr == nullptr) {
+                    throw mkl::invalid_argument("DFT", "set_value", "config_param is nullptr.");
+                }
                 std::copy(ptr, ptr + values_.rank + 1, values_.dimensions.begin());
             }
             break;
@@ -106,6 +109,9 @@ template <precision prec, domain dom>
 descriptor<prec, dom>::descriptor(std::vector<std::int64_t> dimensions)
         : dimensions_(std::move(dimensions)),
           rank_(dimensions.size()) {
+    if (dimensions_.size() == 0) {
+        throw mkl::invalid_argument("DFT", "descriptor", "Cannot have 0 dimensional DFT.");
+    }
     // Compute default strides - see MKL C interface developer reference for CCE format.
     std::vector<std::int64_t> strides(rank_ + 1, 1);
     // The first variable stide value is different.
@@ -150,6 +156,11 @@ void descriptor<prec, dom>::get_value(config_param param, ...) {
     int err = 0;
     using real_t = std::conditional_t<prec == precision::SINGLE, float, double>;
     va_list vl;
+    va_start(vl, param);
+    if (va_arg(vl, void*) == nullptr) {
+        throw mkl::invalid_argument("DFT", "get_value", "config_param is nullptr.");
+    }
+    va_end(vl);
     va_start(vl, param);
     switch (param) {
         case config_param::FORWARD_DOMAIN: *va_arg(vl, dft::domain*) = dom; break;

--- a/src/dft/descriptor.cxx
+++ b/src/dft/descriptor.cxx
@@ -49,7 +49,7 @@ void descriptor<prec, dom>::set_value(config_param param, ...) {
                 if (ptr == nullptr) {
                     throw mkl::invalid_argument("DFT", "set_value", "config_param is nullptr.");
                 }
-                std::copy(ptr, ptr + values_.rank + 1, values_.dimensions.begin());
+                std::copy(ptr, ptr + values_.rank, values_.dimensions.begin());
             }
             break;
         }
@@ -63,10 +63,10 @@ void descriptor<prec, dom>::set_value(config_param param, ...) {
                 throw mkl::invalid_argument("DFT", "set_value", "Invalid config_param argument.");
             }
             else if (param == config_param::INPUT_STRIDES) {
-                std::copy(strides, strides + values_.rank + 1, values_.input_strides.begin());
+                std::copy(strides, strides + values_.rank, values_.input_strides.begin());
             }
             else if (param == config_param::OUTPUT_STRIDES) {
-                std::copy(strides, strides + values_.rank + 1, values_.output_strides.begin());
+                std::copy(strides, strides + values_.rank, values_.output_strides.begin());
             }
             break;
         }

--- a/src/dft/descriptor.cxx
+++ b/src/dft/descriptor.cxx
@@ -27,40 +27,10 @@ namespace mkl {
 namespace dft {
 namespace detail {
 
-// Compute the default strides for a domain. Modifies real_strides and complex_strides
-// argument.
-template <domain dom>
-static void compute_default_strides(const std::vector<std::int64_t>& dimensions, int rank,
-                                    std::vector<std::int64_t>& input_strides,
-                                    std::vector<std::int64_t>& output_strides);
-
-template <>
-void compute_default_strides<domain::REAL>(const std::vector<std::int64_t>& dimensions, int rank,
-                                           std::vector<std::int64_t>& input_strides,
-                                           std::vector<std::int64_t>& output_strides) {
-    // Compute strides for CCE format.
-    // See MKL C interface developer reference for explanation of the below.
-    std::vector<std::int64_t> strides(rank + 1, 1);
-    // The first variable stride value is different.
-    if (rank > 1) {
-        strides[rank - 1] = dimensions[rank - 1] / 2 + 1;
-    }
-    for (int i = rank - 2; i > 0; --i) {
-        strides[i] = strides[i + 1] * dimensions[i];
-    }
-    strides[0] = 0;
-    output_strides = strides;
-    for (int i = 1; i < rank; ++i) {
-        strides[i] *= 2;
-    }
-    input_strides = std::move(strides);
-}
-
-template <>
-void compute_default_strides<domain::COMPLEX>(const std::vector<std::int64_t>& dimensions, int rank,
-                                              std::vector<std::int64_t>& input_strides,
-                                              std::vector<std::int64_t>& output_strides) {
-    // Default is for COMPLEX_COMPLEX storage
+// Compute the default strides. Modifies real_strides and complex_strides arguments.
+void compute_default_strides(const std::vector<std::int64_t>& dimensions, int rank,
+                             std::vector<std::int64_t>& input_strides,
+                             std::vector<std::int64_t>& output_strides) {
     std::vector<std::int64_t> strides(rank + 1, 1);
     for (int i = rank - 1; i > 0; --i) {
         strides[i] = strides[i + 1] * dimensions[i];
@@ -166,7 +136,7 @@ descriptor<prec, dom>::descriptor(std::vector<std::int64_t> dimensions)
         }
     }
     // Assume forward transform.
-    compute_default_strides<dom>(dimensions_, rank_, values_.input_strides, values_.output_strides);
+    compute_default_strides(dimensions_, rank_, values_.input_strides, values_.output_strides);
     values_.bwd_scale = 1.0;
     values_.fwd_scale = 1.0;
     values_.number_of_transforms = 1;

--- a/src/dft/descriptor_config_helper.hpp
+++ b/src/dft/descriptor_config_helper.hpp
@@ -1,0 +1,319 @@
+/*******************************************************************************
+* Copyright Codeplay Software Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#ifndef _ONEMKL_DETAIL_DESCRIPTOR_CONFIG_HELPER_HPP_
+#define _ONEMKL_DETAIL_DESCRIPTOR_CONFIG_HELPER_HPP_
+
+#include <cstdint>
+#include <type_traits>
+
+#include "oneapi/mkl/dft/descriptor.hpp"
+
+namespace oneapi {
+namespace mkl {
+namespace dft {
+namespace detail {
+
+/// Helper to get real type from precision.
+template <precision Prec>
+struct real_helper;
+
+template <>
+struct real_helper<precision::SINGLE> {
+    using type = float;
+};
+
+template <>
+struct real_helper<precision::DOUBLE> {
+    using type = double;
+};
+
+template <precision Prec>
+using real_helper_t = typename real_helper<Prec>::type;
+
+/** Helper to get the argument type for a config param.
+ * @tparam RealT The real type for the DFT.
+ * @tparam Param The config param to get the arg for.
+**/
+template <typename RealT, config_param Param>
+struct param_type_helper;
+
+template <typename RealT, config_param Param>
+using param_type_helper_t = typename param_type_helper<RealT, Param>::type;
+
+#define PARAM_TYPE_HELPER(param, param_type) \
+    template <typename RealT>                \
+    struct param_type_helper<RealT, param> { \
+        using type = param_type;             \
+    };
+PARAM_TYPE_HELPER(config_param::FORWARD_DOMAIN, domain)
+PARAM_TYPE_HELPER(config_param::DIMENSION, std::int64_t)
+PARAM_TYPE_HELPER(config_param::LENGTHS, std::int64_t*)
+PARAM_TYPE_HELPER(config_param::PRECISION, precision)
+PARAM_TYPE_HELPER(config_param::FORWARD_SCALE, RealT)
+PARAM_TYPE_HELPER(config_param::BACKWARD_SCALE, RealT)
+PARAM_TYPE_HELPER(config_param::NUMBER_OF_TRANSFORMS, std::int64_t)
+PARAM_TYPE_HELPER(config_param::COMPLEX_STORAGE, config_value)
+PARAM_TYPE_HELPER(config_param::REAL_STORAGE, config_value)
+PARAM_TYPE_HELPER(config_param::CONJUGATE_EVEN_STORAGE, config_value)
+PARAM_TYPE_HELPER(config_param::PLACEMENT, config_value)
+PARAM_TYPE_HELPER(config_param::INPUT_STRIDES, std::int64_t*)
+PARAM_TYPE_HELPER(config_param::OUTPUT_STRIDES, std::int64_t*)
+PARAM_TYPE_HELPER(config_param::FWD_DISTANCE, std::int64_t)
+PARAM_TYPE_HELPER(config_param::BWD_DISTANCE, std::int64_t)
+PARAM_TYPE_HELPER(config_param::WORKSPACE, config_value)
+PARAM_TYPE_HELPER(config_param::ORDERING, config_value)
+PARAM_TYPE_HELPER(config_param::TRANSPOSE, bool)
+PARAM_TYPE_HELPER(config_param::PACKED_FORMAT, config_value)
+PARAM_TYPE_HELPER(config_param::COMMIT_STATUS, config_value)
+#undef PARAM_TYPE_HELPER
+
+/** Helper struct to set value in dft_values, throwing on invalid args.
+ * @tparam Param The config param to set.
+ * @tparam prec The precision of the DFT.
+ * @tparam dom The domain of the DFT.
+**/
+template <config_param Param, precision prec, domain dom>
+struct set_value_helper;
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::LENGTHS, prec, dom> {
+    static void set_val(dft_values<prec, dom>& vals,
+                        param_type_helper_t<real_helper_t<prec>, config_param::LENGTHS>& set_val) {
+        int rank = vals.rank;
+        if (set_val == nullptr) {
+            throw mkl::invalid_argument("DFT", "set_value", "Given nullptr.");
+        }
+        for (int i{ 0 }; i < rank; ++i) {
+            if (set_val[i] <= 0) {
+                throw mkl::invalid_argument("DFT", "set_value",
+                                            "Invalid length value (negative or 0).");
+            }
+        }
+        std::copy(set_val, set_val + rank, vals.dimensions.begin());
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::PRECISION, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::PRECISION>& set_val) {
+        throw mkl::invalid_argument("DFT", "set_value", "Read-only parameter.");
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::FORWARD_SCALE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::FORWARD_SCALE>& set_val) {
+        vals.fwd_scale = set_val;
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::BACKWARD_SCALE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::BACKWARD_SCALE>& set_val) {
+        vals.bwd_scale = set_val;
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::NUMBER_OF_TRANSFORMS, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::NUMBER_OF_TRANSFORMS>& set_val) {
+        if (set_val <= 0) {
+            throw mkl::invalid_argument("DFT", "set_value",
+                                        "Number of transforms must be positive.");
+        }
+        vals.number_of_transforms = set_val;
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::COMPLEX_STORAGE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::COMPLEX_STORAGE>& set_val) {
+        if (set_val == config_value::COMPLEX_COMPLEX || set_val == config_value::REAL_REAL) {
+            vals.complex_storage = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value",
+                                        "Complex storage must be complex_complex or real_real.");
+        }
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::REAL_STORAGE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::REAL_STORAGE>& set_val) {
+        if (set_val == config_value::REAL_REAL) {
+            vals.real_storage = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value", "Real storage must be real_real.");
+        }
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::CONJUGATE_EVEN_STORAGE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::CONJUGATE_EVEN_STORAGE>& set_val) {
+        if (set_val == config_value::COMPLEX_COMPLEX) {
+            vals.conj_even_storage = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value",
+                                        "Conjugate even storage must be complex_complex.");
+        }
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::PLACEMENT, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::PLACEMENT>& set_val) {
+        if (set_val == config_value::INPLACE || set_val == config_value::NOT_INPLACE) {
+            vals.placement = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value",
+                                        "Placement must be inplace or not inplace.");
+        }
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::INPUT_STRIDES, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::INPUT_STRIDES>& set_val) {
+        int rank = vals.rank;
+        if (set_val == nullptr) {
+            throw mkl::invalid_argument("DFT", "set_value", "Given nullptr.");
+        }
+        std::copy(set_val, set_val + vals.rank, vals.input_strides.begin());
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::OUTPUT_STRIDES, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::OUTPUT_STRIDES>& set_val) {
+        int rank = vals.rank;
+        if (set_val == nullptr) {
+            throw mkl::invalid_argument("DFT", "set_value", "Given nullptr.");
+        }
+        std::copy(set_val, set_val + vals.rank, vals.output_strides.begin());
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::FWD_DISTANCE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::FWD_DISTANCE>& set_val) {
+        vals.fwd_dist = set_val;
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::BWD_DISTANCE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::BWD_DISTANCE>& set_val) {
+        vals.bwd_dist = set_val;
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::WORKSPACE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::WORKSPACE>& set_val) {
+        if (set_val == config_value::ALLOW || set_val == config_value::AVOID) {
+            vals.workspace = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value", "Workspace must be allow or avoid.");
+        }
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::ORDERING, prec, dom> {
+    static void set_val(dft_values<prec, dom>& vals,
+                        param_type_helper_t<real_helper_t<prec>, config_param::ORDERING>& set_val) {
+        if (set_val == config_value::ORDERED || set_val == config_value::BACKWARD_SCRAMBLED) {
+            vals.ordering = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value",
+                                        "Ordering must be ordered or backwards scrambled.");
+        }
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::TRANSPOSE, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::TRANSPOSE>& set_val) {
+        vals.transpose = set_val;
+    }
+};
+
+template <precision prec, domain dom>
+struct set_value_helper<config_param::PACKED_FORMAT, prec, dom> {
+    static void set_val(
+        dft_values<prec, dom>& vals,
+        param_type_helper_t<real_helper_t<prec>, config_param::PACKED_FORMAT>& set_val) {
+        if (set_val == config_value::CCE_FORMAT) {
+            vals.packed_format = set_val;
+        }
+        else {
+            throw mkl::invalid_argument("DFT", "set_value", "Packed format must be CCE.");
+        }
+    }
+};
+
+template <config_param Param, precision prec, domain dom>
+void set_value(dft_values<prec, dom>& vals,
+               param_type_helper_t<real_helper_t<prec>, Param> set_val) {
+    // Note, set_val argument cannot be a ref for use with va_arg.
+    set_value_helper<Param, prec, dom>::set_val(vals, set_val);
+}
+
+} // namespace detail
+} // namespace dft
+} // namespace mkl
+} // namespace oneapi
+
+#endif //_ONEMKL_DETAIL_DESCRIPTOR_CONFIG_HELPER_HPP_

--- a/src/dft/descriptor_config_helper.hpp
+++ b/src/dft/descriptor_config_helper.hpp
@@ -218,7 +218,7 @@ struct set_value_helper<config_param::INPUT_STRIDES, prec, dom> {
         if (set_val == nullptr) {
             throw mkl::invalid_argument("DFT", "set_value", "Given nullptr.");
         }
-        std::copy(set_val, set_val + vals.rank, vals.input_strides.begin());
+        std::copy(set_val, set_val + vals.rank + 1, vals.input_strides.begin());
     }
 };
 
@@ -231,7 +231,7 @@ struct set_value_helper<config_param::OUTPUT_STRIDES, prec, dom> {
         if (set_val == nullptr) {
             throw mkl::invalid_argument("DFT", "set_value", "Given nullptr.");
         }
-        std::copy(set_val, set_val + vals.rank, vals.output_strides.begin());
+        std::copy(set_val, set_val + vals.rank + 1, vals.output_strides.begin());
     }
 };
 


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant
motivation and context. See
[contribution guidelines](https://github.com/oneapi-src/oneMKL/blob/master/CONTRIBUTING.md)
for more details. If the change fixes an issue not documented in the project's
Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (GitHub issue)

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [ ] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
