### PR TITLE
[DFT] compute_forward + compute_backwards; Implementation for MKLGPU

### DIFF
--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -45,7 +45,7 @@ public:
               backend_(other.backend_),
               status(other.status) {}
 
-    virtual ~commit_impl() {}
+    virtual ~commit_impl() = default;
 
     sycl::queue& get_queue() {
         return queue_;

--- a/include/oneapi/mkl/dft/detail/commit_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/commit_impl.hpp
@@ -26,6 +26,8 @@
 #include <CL/sycl.hpp>
 #endif
 
+#include "oneapi/mkl/detail/backends.hpp"
+
 namespace oneapi {
 namespace mkl {
 namespace dft {
@@ -33,9 +35,15 @@ namespace detail {
 
 class commit_impl {
 public:
-    commit_impl(sycl::queue queue) : queue_(queue), status(false) {}
+    commit_impl(sycl::queue queue, mkl::backend backend)
+            : queue_(queue),
+              backend_(backend),
+              status(false) {}
 
-    commit_impl(const commit_impl& other) : queue_(other.queue_), status(other.status) {}
+    commit_impl(const commit_impl& other)
+            : queue_(other.queue_),
+              backend_(other.backend_),
+              status(other.status) {}
 
     virtual ~commit_impl() {}
 
@@ -43,8 +51,15 @@ public:
         return queue_;
     }
 
+    mkl::backend& get_backend() {
+        return backend_;
+    }
+
+    virtual void* get_handle() = 0;
+
 protected:
     bool status;
+    mkl::backend backend_;
     sycl::queue queue_;
 };
 

--- a/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
+++ b/include/oneapi/mkl/dft/detail/descriptor_impl.hpp
@@ -36,6 +36,12 @@ namespace oneapi {
 namespace mkl {
 namespace dft {
 namespace detail {
+// Forward declaration:
+template <precision prec, domain dom>
+class descriptor;
+
+template <precision prec, domain dom>
+inline commit_impl* get_commit(descriptor<prec, dom>& desc);
 
 template <precision prec, domain dom>
 class descriptor {
@@ -70,7 +76,7 @@ public:
     };
 
 private:
-    std::unique_ptr<detail::commit_impl> pimpl_; // commit only
+    std::unique_ptr<commit_impl> pimpl_; // commit only
     sycl::queue queue_;
 
     std::int64_t rank_;
@@ -78,7 +84,14 @@ private:
 
     // descriptor configuration values_ and structs
     dft_values<prec, dom> values_;
+
+    friend commit_impl* get_commit<prec, dom>(descriptor<prec, dom>&);
 };
+
+template <precision prec, domain dom>
+inline commit_impl* get_commit(descriptor<prec, dom>& desc) {
+    return desc.pimpl_.get();
+}
 
 } // namespace detail
 } // namespace dft

--- a/include/oneapi/mkl/dft/detail/dft_ct.hxx
+++ b/include/oneapi/mkl/dft/detail/dft_ct.hxx
@@ -1,0 +1,119 @@
+/*******************************************************************************
+* Copyright 2022 Codeplay Software
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+// Commit
+
+template <dft::detail::precision prec, dft::detail::domain dom>
+ONEMKL_EXPORT dft::detail::commit_impl *create_commit(dft::detail::descriptor<prec, dom> &desc);
+
+// BUFFER version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout);
+
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
+                                   sycl::buffer<data_type, 1> &inout_im);
+
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
+                                   sycl::buffer<output_type, 1> &out);
+
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
+                                   sycl::buffer<input_type, 1> &in_im,
+                                   sycl::buffer<output_type, 1> &out_re,
+                                   sycl::buffer<output_type, 1> &out_im);
+
+//USM version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout,
+                                          const std::vector<sycl::event> &dependencies = {});
+
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout_re,
+                                          data_type *inout_im,
+                                          const std::vector<sycl::event> &dependencies = {});
+
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in, output_type *out,
+                                          const std::vector<sycl::event> &dependencies = {});
+
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in_re,
+                                          input_type *in_im, output_type *out_re,
+                                          output_type *out_im,
+                                          const std::vector<sycl::event> &dependencies = {});
+
+// BUFFER version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout);
+
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
+                                    sycl::buffer<data_type, 1> &inout_im);
+
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
+                                    sycl::buffer<output_type, 1> &out);
+
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
+                                    sycl::buffer<input_type, 1> &in_im,
+                                    sycl::buffer<output_type, 1> &out_re,
+                                    sycl::buffer<output_type, 1> &out_im);
+
+//USM version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout,
+                                           const std::vector<sycl::event> &dependencies = {});
+
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout_re,
+                                           data_type *inout_im,
+                                           const std::vector<sycl::event> &dependencies = {});
+
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in, output_type *out,
+                                           const std::vector<sycl::event> &dependencies = {});
+
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in_re,
+                                           input_type *in_im, output_type *out_re,
+                                           output_type *out_im,
+                                           const std::vector<sycl::event> &dependencies = {});

--- a/include/oneapi/mkl/dft/detail/mklcpu/onemkl_dft_mklcpu.hpp
+++ b/include/oneapi/mkl/dft/detail/mklcpu/onemkl_dft_mklcpu.hpp
@@ -20,6 +20,12 @@
 #ifndef _ONEMKL_DFT_MKLCPU_HPP_
 #define _ONEMKL_DFT_MKLCPU_HPP_
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
 #include "oneapi/mkl/detail/export.hpp"
 #include "oneapi/mkl/dft/detail/types_impl.hpp"
 
@@ -36,8 +42,8 @@ class descriptor;
 } // namespace detail
 
 namespace mklcpu {
-template <dft::detail::precision prec, dft::detail::domain dom>
-ONEMKL_EXPORT dft::detail::commit_impl* create_commit(dft::detail::descriptor<prec, dom>& desc);
+
+#include "oneapi/mkl/dft/detail/dft_ct.hxx"
 
 } // namespace mklcpu
 } // namespace dft

--- a/include/oneapi/mkl/dft/detail/mklgpu/onemkl_dft_mklgpu.hpp
+++ b/include/oneapi/mkl/dft/detail/mklgpu/onemkl_dft_mklgpu.hpp
@@ -20,7 +20,6 @@
 #ifndef _ONEMKL_DFT_MKLGPU_HPP_
 #define _ONEMKL_DFT_MKLGPU_HPP_
 
-#include <cstdint>
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
 #else
@@ -43,8 +42,8 @@ class descriptor;
 } // namespace detail
 
 namespace mklgpu {
-template <dft::detail::precision prec, dft::detail::domain dom>
-ONEMKL_EXPORT dft::detail::commit_impl* create_commit(dft::detail::descriptor<prec, dom>& desc);
+
+#include "oneapi/mkl/dft/detail/dft_ct.hxx"
 
 } // namespace mklgpu
 } // namespace dft

--- a/src/dft/backends/backend_backward_instantiations.cxx
+++ b/src/dft/backends/backend_backward_instantiations.cxx
@@ -54,6 +54,7 @@ ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_CF, float, std::complex<float>, std::com
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_RD, double, double, std::complex<double>)
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_CD, double, std::complex<double>, std::complex<double>)
 
+#undef ONEMKL_DFT_BACKWARD_INSTANTIATIONS
 #undef DOM_REAL
 #undef DOM_COMPLEX
 #undef PREC_F32

--- a/src/dft/backends/backend_backward_instantiations.cxx
+++ b/src/dft/backends/backend_backward_instantiations.cxx
@@ -1,0 +1,65 @@
+/*******************************************************************************
+* Copyright 2022 Codeplay Software Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#define DOM_REAL      dft::detail::domain::REAL
+#define DOM_COMPLEX   dft::detail::domain::COMPLEX
+#define PREC_F        dft::detail::precision::SINGLE
+#define PREC_D        dft::detail::precision::DOUBLE
+#define DESC_RF       dft::detail::descriptor<PREC_F, DOM_REAL>
+#define DESC_CF       dft::detail::descriptor<PREC_F, DOM_COMPLEX>
+#define DESC_RD       dft::detail::descriptor<PREC_D, DOM_REAL>
+#define DESC_CD       dft::detail::descriptor<PREC_D, DOM_COMPLEX>
+#define DEPENDS_VEC_T const std::vector<sycl::event> &
+
+#define ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)       \
+    /* Buffer API */                                                                          \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T>(                   \
+        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &);                                     \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>(        \
+        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &, sycl::buffer<FORWARD_T> &);          \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T>(                       \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                 \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(               \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                  \
+        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                      \
+                                                                                              \
+    /* USM API */                                                                             \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T>(            \
+        DESCRIPTOR_T & desc, BACKWARD_T *, DEPENDS_VEC_T);                                    \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>( \
+        DESCRIPTOR_T & desc, BACKWARD_T *, FORWARD_T *, DEPENDS_VEC_T);                       \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T>(                \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                              \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(        \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, DEPENDS_VEC_T);
+
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_RF, float, float, std::complex<float>)
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_CF, float, std::complex<float>, std::complex<float>)
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_RD, double, double, std::complex<double>)
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_CD, double, std::complex<double>, std::complex<double>)
+
+#undef DOM_REAL
+#undef DOM_COMPLEX
+#undef PREC_F32
+#undef PREC_F64
+#undef DESC_RF32
+#undef DESC_CF32
+#undef DESC_RF64
+#undef DESC_CF64
+#undef DEPENDS_VEC_T

--- a/src/dft/backends/backend_forward_instantiations.cxx
+++ b/src/dft/backends/backend_forward_instantiations.cxx
@@ -1,0 +1,65 @@
+/*******************************************************************************
+* Copyright 2022 Codeplay Software Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+#define DOM_REAL      dft::detail::domain::REAL
+#define DOM_COMPLEX   dft::detail::domain::COMPLEX
+#define PREC_F        dft::detail::precision::SINGLE
+#define PREC_D        dft::detail::precision::DOUBLE
+#define DESC_RF       dft::detail::descriptor<PREC_F, DOM_REAL>
+#define DESC_CF       dft::detail::descriptor<PREC_F, DOM_COMPLEX>
+#define DESC_RD       dft::detail::descriptor<PREC_D, DOM_REAL>
+#define DESC_CD       dft::detail::descriptor<PREC_D, DOM_COMPLEX>
+#define DEPENDS_VEC_T const std::vector<sycl::event> &
+
+#define ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)       \
+    /* Buffer API */                                                                         \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, FORWARD_T>(                    \
+        DESCRIPTOR_T & desc, sycl::buffer<FORWARD_T> &);                                     \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(        \
+        DESCRIPTOR_T & desc, sycl::buffer<FORWARD_T> &, sycl::buffer<BACKWARD_T> &);         \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(                       \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(               \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                 \
+        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                     \
+                                                                                             \
+    /* USM API */                                                                            \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T>(             \
+        DESCRIPTOR_T & desc, FORWARD_T *, DEPENDS_VEC_T);                                    \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>( \
+        DESCRIPTOR_T & desc, FORWARD_T *, BACKWARD_T *, DEPENDS_VEC_T);                      \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                             \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(        \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, DEPENDS_VEC_T);
+
+ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_RF, float, float, std::complex<float>)
+ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_CF, float, std::complex<float>, std::complex<float>)
+ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_RD, double, double, std::complex<double>)
+ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_CD, double, std::complex<double>, std::complex<double>)
+
+#undef DOM_REAL
+#undef DOM_COMPLEX
+#undef PREC_F32
+#undef PREC_F64
+#undef DESC_RF32
+#undef DESC_CF32
+#undef DESC_RF64
+#undef DESC_CF64
+#undef DEPENDS_VEC_T

--- a/src/dft/backends/backend_forward_instantiations.cxx
+++ b/src/dft/backends/backend_forward_instantiations.cxx
@@ -54,6 +54,7 @@ ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_CF, float, std::complex<float>, std::comp
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_RD, double, double, std::complex<double>)
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_CD, double, std::complex<double>, std::complex<double>)
 
+#undef ONEMKL_DFT_FORWARD_INSTANTIATIONS
 #undef DOM_REAL
 #undef DOM_COMPLEX
 #undef PREC_F32

--- a/src/dft/backends/backend_wrappers.cxx
+++ b/src/dft/backends/backend_wrappers.cxx
@@ -36,57 +36,61 @@ function template instantiations must be added to backend_backward_instantiation
 and backend_forward_instantiations.cxx.
 */
 
-oneapi::mkl::dft::BACKEND::create_commit, oneapi::mkl::dft::BACKEND::create_commit,
-    oneapi::mkl::dft::BACKEND::create_commit, oneapi::mkl::dft::BACKEND::create_commit,
+// clang-format off
+oneapi::mkl::dft::BACKEND::create_commit,
+oneapi::mkl::dft::BACKEND::create_commit,
+oneapi::mkl::dft::BACKEND::create_commit,
+oneapi::mkl::dft::BACKEND::create_commit,
 #define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)  \
     /* Buffer API */                                                                         \
     oneapi::mkl::dft::BACKEND::compute_forward<                                              \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>,                 \
-        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                \
-        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>, \
-        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                 \
-            T_REAL>, /* USM API */                                                           \
-        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>,             \
-        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                \
-        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>, \
-        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                 \
-            T_REAL>, /* Buffer API */                                                        \
-        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,            \
-        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                \
-        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>, \
-        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                 \
-            T_REAL>, /* USM API */                                                           \
-        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,            \
-        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                \
-        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>, \
-        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
-            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                     \
+        T_REAL>, /* USM API */                                                               \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>,                 \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                     \
+        T_REAL>, /* Buffer API */                                                            \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                     \
+        T_REAL>, /* USM API */                                                               \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,
 
-    ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::SINGLE,
-                                      oneapi::mkl::dft::detail::domain::REAL, float, float,
-                                      std::complex<float>)
-        ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::SINGLE,
-                                          oneapi::mkl::dft::detail::domain::COMPLEX, float,
-                                          std::complex<float>, std::complex<float>)
-            ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::DOUBLE,
-                                              oneapi::mkl::dft::detail::domain::REAL, double,
-                                              double, std::complex<double>)
-                ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::DOUBLE,
-                                                  oneapi::mkl::dft::detail::domain::COMPLEX, double,
-                                                  std::complex<double>, std::complex<double>)
+ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::SINGLE,
+                                  oneapi::mkl::dft::detail::domain::REAL, float, float,
+                                  std::complex<float>)
+ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::SINGLE,
+                                  oneapi::mkl::dft::detail::domain::COMPLEX, float,
+                                  std::complex<float>, std::complex<float>)
+ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::DOUBLE,
+                                  oneapi::mkl::dft::detail::domain::REAL, double,
+                                  double, std::complex<double>)
+ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::DOUBLE,
+                                  oneapi::mkl::dft::detail::domain::COMPLEX, double,
+                                  std::complex<double>, std::complex<double>)
+// clang-format on
 
 #undef ONEAPI_MKL_DFT_BACKEND_SIGNATURES

--- a/src/dft/backends/backend_wrappers.cxx
+++ b/src/dft/backends/backend_wrappers.cxx
@@ -17,6 +17,25 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+/*
+This file lists functions matching those required by dft_function_table_t in 
+src/dft/function_table.hpp.
+
+To use this:
+
+#define WRAPPER_VERSION <Wrapper version number>
+#define BACKEND         <Backend name eg. mklgpu>
+
+extern "C" dft_function_table_t mkl_dft_table = {
+    WRAPPER_VERSION,
+#include "dft/backends/backend_wrappers.cxx"
+};
+
+Changes to this file should be matched to changes in function_table.hpp. The required 
+function template instantiations must be added to backend_backward_instantiations.cxx 
+and backend_forward_instantiations.cxx.
+*/
+
 oneapi::mkl::dft::BACKEND::create_commit, oneapi::mkl::dft::BACKEND::create_commit,
     oneapi::mkl::dft::BACKEND::create_commit, oneapi::mkl::dft::BACKEND::create_commit,
 #define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)  \

--- a/src/dft/backends/backend_wrappers.cxx
+++ b/src/dft/backends/backend_wrappers.cxx
@@ -1,0 +1,73 @@
+/*******************************************************************************
+* Copyright 2022 Codeplay Software Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
+
+oneapi::mkl::dft::BACKEND::create_commit, oneapi::mkl::dft::BACKEND::create_commit,
+    oneapi::mkl::dft::BACKEND::create_commit, oneapi::mkl::dft::BACKEND::create_commit,
+#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)  \
+    /* Buffer API */                                                                         \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>,                 \
+        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                \
+        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>, \
+        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                 \
+            T_REAL>, /* USM API */                                                           \
+        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>,             \
+        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                \
+        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>, \
+        oneapi::mkl::dft::BACKEND::compute_forward<                                          \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                 \
+            T_REAL>, /* Buffer API */                                                        \
+        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,            \
+        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                \
+        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>, \
+        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                 \
+            T_REAL>, /* USM API */                                                           \
+        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,            \
+        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                \
+        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>, \
+        oneapi::mkl::dft::BACKEND::compute_backward<                                         \
+            oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,
+
+    ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::SINGLE,
+                                      oneapi::mkl::dft::detail::domain::REAL, float, float,
+                                      std::complex<float>)
+        ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::SINGLE,
+                                          oneapi::mkl::dft::detail::domain::COMPLEX, float,
+                                          std::complex<float>, std::complex<float>)
+            ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::DOUBLE,
+                                              oneapi::mkl::dft::detail::domain::REAL, double,
+                                              double, std::complex<double>)
+                ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::DOUBLE,
+                                                  oneapi::mkl::dft::detail::domain::COMPLEX, double,
+                                                  std::complex<double>, std::complex<double>)
+
+#undef ONEAPI_MKL_DFT_BACKEND_SIGNATURES

--- a/src/dft/backends/mklcpu/backward.cpp
+++ b/src/dft/backends/mklcpu/backward.cpp
@@ -25,6 +25,7 @@
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/dft/types.hpp"
+#include "oneapi/mkl/detail/exceptions.hpp"
 
 #include "oneapi/mkl/dft/descriptor.hpp"
 #include "oneapi/mkl/dft/detail/mklcpu/onemkl_dft_mklcpu.hpp"
@@ -34,174 +35,76 @@ namespace mkl {
 namespace dft {
 namespace mklcpu {
 
-void compute_backward_buffer_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                       sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                       sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                       sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                       sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
+// BUFFER version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
 }
 
-void compute_backward_buffer_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                             sycl::buffer<float, 1> &inout_re,
-                                             sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_inplace_split_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                             sycl::buffer<float, 1> &inout_re,
-                                             sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                             sycl::buffer<double, 1> &inout_re,
-                                             sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_inplace_split_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                             sycl::buffer<double, 1> &inout_re,
-                                             sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
+                                    sycl::buffer<data_type, 1> &inout_im) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
 }
 
-void compute_backward_buffer_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                          sycl::buffer<std::complex<float>, 1> &in,
-                                          sycl::buffer<float, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                          sycl::buffer<std::complex<float>, 1> &in,
-                                          sycl::buffer<std::complex<float>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                          sycl::buffer<std::complex<double>, 1> &in,
-                                          sycl::buffer<double, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                          sycl::buffer<std::complex<double>, 1> &in,
-                                          sycl::buffer<std::complex<double>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
+                                    sycl::buffer<output_type, 1> &out) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
 }
 
-void compute_backward_buffer_outofplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                                sycl::buffer<float, 1> &in_re,
-                                                sycl::buffer<float, 1> &in_im,
-                                                sycl::buffer<float, 1> &out_re,
-                                                sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_outofplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, sycl::buffer<float, 1> &in_re,
-    sycl::buffer<float, 1> &in_im, sycl::buffer<float, 1> &out_re, sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_outofplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                                sycl::buffer<double, 1> &in_re,
-                                                sycl::buffer<double, 1> &in_im,
-                                                sycl::buffer<double, 1> &out_re,
-                                                sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_backward_buffer_outofplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, sycl::buffer<double, 1> &in_re,
-    sycl::buffer<double, 1> &in_im, sycl::buffer<double, 1> &out_re,
-    sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
+                                    sycl::buffer<input_type, 1> &in_im,
+                                    sycl::buffer<output_type, 1> &out_re,
+                                    sycl::buffer<output_type, 1> &out_im) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
 }
 
-sycl::event compute_backward_usm_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                           std::complex<float> *inout,
+//USM version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout,
                                            const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                           std::complex<float> *inout,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                           std::complex<double> *inout,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                           std::complex<double> *inout,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
 
-sycl::event compute_backward_usm_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                                 float *inout_re, float *inout_im,
-                                                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_inplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *inout_re, float *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                                 double *inout_re, double *inout_im,
-                                                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_inplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *inout_re, double *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout_re,
+                                           data_type *inout_im,
+                                           const std::vector<sycl::event> &dependencies) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
 
-sycl::event compute_backward_usm_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                              std::complex<float> *in, float *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                              std::complex<float> *in, std::complex<float> *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                              std::complex<double> *in, double *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                              std::complex<double> *in, std::complex<double> *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in, output_type *out,
+                                           const std::vector<sycl::event> &dependencies) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
 
-sycl::event compute_backward_usm_outofplace_split_f(
-    descriptor<precision::SINGLE, domain::REAL> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in_re,
+                                           input_type *in_im, output_type *out_re,
+                                           output_type *out_im,
+                                           const std::vector<sycl::event> &dependencies) {
+    throw mkl::unimplemented("DFT", "compute_backward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
-sycl::event compute_backward_usm_outofplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_outofplace_split_d(
-    descriptor<precision::DOUBLE, domain::REAL> &desc, double *in_re, double *in_im, double *out_re,
-    double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_backward_usm_outofplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *in_re, double *in_im,
-    double *out_re, double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
+
+// Template function instantiations
+#include "dft/backends/backend_backward_instantiations.cxx"
 
 } // namespace mklcpu
 } // namespace dft

--- a/src/dft/backends/mklcpu/commit.cpp
+++ b/src/dft/backends/mklcpu/commit.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #include "oneapi/mkl/types.hpp"
+#include "oneapi/mkl/detail/backends.hpp"
 #include "oneapi/mkl/dft/types.hpp"
 #include "oneapi/mkl/dft/descriptor.hpp"
 
@@ -42,7 +43,7 @@ template <precision prec, domain dom>
 class commit_derived_impl : public detail::commit_impl {
 public:
     commit_derived_impl(sycl::queue queue, detail::dft_values<prec, dom> config_values)
-            : detail::commit_impl(queue),
+            : detail::commit_impl(queue, backend::mklcpu),
               status(DFT_NOTSET) {
         if (config_values.rank == 1) {
             status = DftiCreateDescriptor(&handle, get_precision(prec), get_domain(dom),
@@ -62,6 +63,10 @@ public:
         if (status != DFTI_NO_ERROR) {
             throw oneapi::mkl::exception("dft", "commit", "DftiCommitDescriptor failed");
         }
+    }
+
+    virtual void* get_handle() override {
+        return handle;
     }
 
     virtual ~commit_derived_impl() override {

--- a/src/dft/backends/mklcpu/forward.cpp
+++ b/src/dft/backends/mklcpu/forward.cpp
@@ -25,6 +25,7 @@
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/dft/types.hpp"
+#include "oneapi/mkl/detail/exceptions.hpp"
 
 #include "oneapi/mkl/dft/descriptor.hpp"
 #include "oneapi/mkl/dft/detail/mklcpu/onemkl_dft_mklcpu.hpp"
@@ -34,177 +35,74 @@ namespace mkl {
 namespace dft {
 namespace mklcpu {
 
-void compute_forward_buffer_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                      sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                      sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                      sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                      sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
 }
 
-void compute_forward_buffer_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                            sycl::buffer<float, 1> &inout_re,
-                                            sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_inplace_split_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                            sycl::buffer<float, 1> &inout_re,
-                                            sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                            sycl::buffer<double, 1> &inout_re,
-                                            sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_inplace_split_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                            sycl::buffer<double, 1> &inout_re,
-                                            sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
+                                   sycl::buffer<data_type, 1> &inout_im) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
 }
 
-void compute_forward_buffer_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                         sycl::buffer<float, 1> &in,
-                                         sycl::buffer<std::complex<float>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                         sycl::buffer<std::complex<float>, 1> &in,
-                                         sycl::buffer<std::complex<float>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                         sycl::buffer<double, 1> &in,
-                                         sycl::buffer<std::complex<double>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                         sycl::buffer<std::complex<double>, 1> &in,
-                                         sycl::buffer<std::complex<double>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
+                                   sycl::buffer<output_type, 1> &out) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
 }
 
-void compute_forward_buffer_outofplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                               sycl::buffer<float, 1> &in_re,
-                                               sycl::buffer<float, 1> &in_im,
-                                               sycl::buffer<float, 1> &out_re,
-                                               sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_outofplace_split_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                               sycl::buffer<float, 1> &in_re,
-                                               sycl::buffer<float, 1> &in_im,
-                                               sycl::buffer<float, 1> &out_re,
-                                               sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_outofplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                               sycl::buffer<double, 1> &in_re,
-                                               sycl::buffer<double, 1> &in_im,
-                                               sycl::buffer<double, 1> &out_re,
-                                               sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-void compute_forward_buffer_outofplace_split_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                               sycl::buffer<double, 1> &in_re,
-                                               sycl::buffer<double, 1> &in_im,
-                                               sycl::buffer<double, 1> &out_re,
-                                               sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
+                                   sycl::buffer<input_type, 1> &in_im,
+                                   sycl::buffer<output_type, 1> &out_re,
+                                   sycl::buffer<output_type, 1> &out_im) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
 }
 
-sycl::event compute_forward_usm_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                          std::complex<float> *inout,
+//USM version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout,
                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                          std::complex<float> *inout,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                          std::complex<double> *inout,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                          std::complex<double> *inout,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
 
-sycl::event compute_forward_usm_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                                float *inout_re, float *inout_im,
-                                                const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_inplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *inout_re, float *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                                double *inout_re, double *inout_im,
-                                                const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_inplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *inout_re, double *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout_re,
+                                          data_type *inout_im,
+                                          const std::vector<sycl::event> &dependencies) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
 
-sycl::event compute_forward_usm_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                             float *in, std::complex<float> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                             std::complex<float> *in, std::complex<float> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                             double *in, std::complex<double> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                             std::complex<double> *in, std::complex<double> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in, output_type *out,
+                                          const std::vector<sycl::event> &dependencies) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
 
-sycl::event compute_forward_usm_outofplace_split_f(
-    descriptor<precision::SINGLE, domain::REAL> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in_re,
+                                          input_type *in_im, output_type *out_re,
+                                          output_type *out_im,
+                                          const std::vector<sycl::event> &dependencies) {
+    throw mkl::unimplemented("DFT", "compute_forward", "Not implemented for MKLCPU");
+    return sycl::event{};
 }
-sycl::event compute_forward_usm_outofplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_outofplace_split_d(
-    descriptor<precision::DOUBLE, domain::REAL> &desc, double *in_re, double *in_im, double *out_re,
-    double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
-sycl::event compute_forward_usm_outofplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *in_re, double *in_im,
-    double *out_re, double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklcpu");
-}
+
+// Template function instantiations
+#include "dft/backends/backend_forward_instantiations.cxx"
 
 } // namespace mklcpu
 } // namespace dft

--- a/src/dft/backends/mklcpu/mkl_dft_cpu_wrappers.cpp
+++ b/src/dft/backends/mklcpu/mkl_dft_cpu_wrappers.cpp
@@ -21,11 +21,9 @@
 #include "dft/function_table.hpp"
 
 #define WRAPPER_VERSION 1
+#define BACKEND         mklcpu
 
 extern "C" dft_function_table_t mkl_dft_table = {
     WRAPPER_VERSION,
-    oneapi::mkl::dft::mklcpu::create_commit,
-    oneapi::mkl::dft::mklcpu::create_commit,
-    oneapi::mkl::dft::mklcpu::create_commit,
-    oneapi::mkl::dft::mklcpu::create_commit
+#include "dft/backends/backend_wrappers.cxx"
 };

--- a/src/dft/backends/mklgpu/CMakeLists.txt
+++ b/src/dft/backends/mklgpu/CMakeLists.txt
@@ -26,8 +26,8 @@ add_library(${LIB_NAME})
 add_library(${LIB_OBJ} OBJECT
   descriptor.cpp
   commit.cpp
-  # forward.cpp
-  # backward.cpp
+  forward.cpp
+  backward.cpp
   $<$<BOOL:${BUILD_SHARED_LIBS}>: mkl_dft_gpu_wrappers.cpp>
 )
 

--- a/src/dft/backends/mklgpu/backward.cpp
+++ b/src/dft/backends/mklgpu/backward.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Intel Corporation
+* Copyright 2022 Codeplay Software Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,182 +24,165 @@
 #endif
 
 #include "oneapi/mkl/types.hpp"
+#include "oneapi/mkl/exceptions.hpp"
 
 #include "oneapi/mkl/dft/detail/mklgpu/onemkl_dft_mklgpu.hpp"
+#include "oneapi/mkl/dft/detail/types_impl.hpp"
+#include "oneapi/mkl/dft/detail/descriptor_impl.hpp"
+#include "dft/backends/mklgpu/mklgpu_helpers.hpp"
+
+// MKLGPU header
+#include "oneapi/mkl/dfti.hpp"
 
 namespace oneapi {
 namespace mkl {
 namespace dft {
 namespace mklgpu {
+namespace detail {
 
-void compute_backward_buffer_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                       sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                       sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                       sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                       sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-
-void compute_backward_buffer_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                             sycl::buffer<float, 1> &inout_re,
-                                             sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_inplace_split_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                             sycl::buffer<float, 1> &inout_re,
-                                             sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                             sycl::buffer<double, 1> &inout_re,
-                                             sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_inplace_split_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                             sycl::buffer<double, 1> &inout_re,
-                                             sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
+/// Forward a MKLGPU DFT call to the backend, checking that the commit impl is valid.
+/// Assumes backend descriptor values match those of the frontend.
+template <dft::detail::precision prec, dft::detail::domain dom, typename... ArgTs>
+inline auto compute_backward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&... args) {
+    using mklgpu_desc_t = dft::descriptor<to_mklgpu(prec), to_mklgpu(dom)>;
+    using commit_t = dft::detail::commit_impl;
+    auto commit_handle = dft::detail::get_commit(desc);
+    if (commit_handle == nullptr || commit_handle->get_backend() != backend::mklgpu) {
+        throw mkl::invalid_argument("DFT", "compute_backward",
+                                    "DFT descriptor has not been commited for MKLGPU");
+    }
+    auto mklgpu_desc = reinterpret_cast<mklgpu_desc_t *>(commit_handle->get_handle());
+    int commit_status{ DFTI_UNCOMMITTED };
+    mklgpu_desc->get_value(dft::config_param::COMMIT_STATUS, &commit_status);
+    if (commit_status != DFTI_COMMITTED) {
+        throw mkl::invalid_argument("DFT", "compute_backward",
+                                    "MKLGPU DFT descriptor was not successfully committed.");
+    }
+    return dft::compute_backward(*mklgpu_desc, std::forward<ArgTs>(args)...);
 }
 
-void compute_backward_buffer_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                          sycl::buffer<std::complex<float>, 1> &in,
-                                          sycl::buffer<float, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
+/// Throw an mkl::invalid_argument if the runtime param in the descriptor does not match
+/// the expected value.
+template <dft::detail::config_param Param, dft::detail::config_value Expected, typename DescT>
+inline auto expect_config(DescT &desc, const char *message) {
+    dft::detail::config_value actual{ 0 };
+    desc.get_value(Param, &actual);
+    if (actual != Expected) {
+        throw mkl::invalid_argument("DFT", "compute_backward", message);
+    }
 }
-void compute_backward_buffer_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                          sycl::buffer<std::complex<float>, 1> &in,
-                                          sycl::buffer<std::complex<float>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                          sycl::buffer<std::complex<double>, 1> &in,
-                                          sycl::buffer<double, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                          sycl::buffer<std::complex<double>, 1> &in,
-                                          sycl::buffer<std::complex<double>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
+} // namespace detail
+
+// BUFFER version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout) {
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    return detail::compute_backward(desc, inout);
 }
 
-void compute_backward_buffer_outofplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                                sycl::buffer<float, 1> &in_re,
-                                                sycl::buffer<float, 1> &in_im,
-                                                sycl::buffer<float, 1> &out_re,
-                                                sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_outofplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, sycl::buffer<float, 1> &in_re,
-    sycl::buffer<float, 1> &in_im, sycl::buffer<float, 1> &out_re, sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_outofplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                                sycl::buffer<double, 1> &in_re,
-                                                sycl::buffer<double, 1> &in_im,
-                                                sycl::buffer<double, 1> &out_re,
-                                                sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_backward_buffer_outofplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, sycl::buffer<double, 1> &in_re,
-    sycl::buffer<double, 1> &in_im, sycl::buffer<double, 1> &out_re,
-    sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
+                                    sycl::buffer<data_type, 1> &inout_im) {
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    return detail::compute_backward(desc, inout_re, inout_im);
 }
 
-sycl::event compute_backward_usm_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                           std::complex<float> *inout,
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
+                                    sycl::buffer<output_type, 1> &out) {
+    if constexpr (!std::is_same_v<input_type, output_type>) {
+        throw mkl::unimplemented(
+            "DFT", "compute_backward",
+            "MKLGPU does not support out-of-place FFT with different input and output types.");
+    }
+    else {
+        detail::expect_config<dft::detail::config_param::PLACEMENT,
+                              dft::detail::config_value::NOT_INPLACE>(
+            desc, "Unexpected value for placement");
+        return detail::compute_backward(desc, in, out);
+    }
+}
+
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
+                                    sycl::buffer<input_type, 1> &in_im,
+                                    sycl::buffer<output_type, 1> &out_re,
+                                    sycl::buffer<output_type, 1> &out_im) {
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    throw oneapi::mkl::unimplemented(
+        "DFT", "compute_backward(desc, in_re, in_im, out_re, out_im)",
+        "MKLGPU does not support out-of-place FFT with real-real complex storage.");
+}
+
+//USM version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout,
                                            const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                           std::complex<float> *inout,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                           std::complex<double> *inout,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                           std::complex<double> *inout,
-                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    return detail::compute_backward(desc, inout, dependencies);
 }
 
-sycl::event compute_backward_usm_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                                 float *inout_re, float *inout_im,
-                                                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_inplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *inout_re, float *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                                 double *inout_re, double *inout_im,
-                                                 const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_inplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *inout_re, double *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout_re,
+                                           data_type *inout_im,
+                                           const std::vector<sycl::event> &dependencies) {
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    return detail::compute_backward(desc, inout_re, inout_im, dependencies);
 }
 
-sycl::event compute_backward_usm_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                              std::complex<float> *in, float *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                              std::complex<float> *in, std::complex<float> *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                              std::complex<double> *in, double *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                              std::complex<double> *in, std::complex<double> *out,
-                                              const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in, output_type *out,
+                                           const std::vector<sycl::event> &dependencies) {
+    if constexpr (!std::is_same_v<input_type, output_type>) {
+        throw mkl::unimplemented(
+            "DFT", "compute_backward",
+            "MKLGPU does not support out-of-place FFT with different input and output types.");
+    }
+    else {
+        detail::expect_config<dft::detail::config_param::PLACEMENT,
+                              dft::detail::config_value::NOT_INPLACE>(
+            desc, "Unexpected value for placement");
+        return detail::compute_backward(desc, in, out, dependencies);
+    }
 }
 
-sycl::event compute_backward_usm_outofplace_split_f(
-    descriptor<precision::SINGLE, domain::REAL> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, input_type *in_re,
+                                           input_type *in_im, output_type *out_re,
+                                           output_type *out_im,
+                                           const std::vector<sycl::event> &dependencies) {
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    throw oneapi::mkl::unimplemented(
+        "DFT", "compute_backward(desc, in_re, in_im, out_re, out_im, deps)",
+        "MKLGPU does not support out-of-place FFT with real-real complex storage.");
 }
-sycl::event compute_backward_usm_outofplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_outofplace_split_d(
-    descriptor<precision::DOUBLE, domain::REAL> &desc, double *in_re, double *in_im, double *out_re,
-    double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_backward_usm_outofplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *in_re, double *in_im,
-    double *out_re, double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
+
+// Template function instantiations
+#include "dft/backends/backend_backward_instantiations.cxx"
 
 } // namespace mklgpu
 } // namespace dft

--- a/src/dft/backends/mklgpu/commit.cpp
+++ b/src/dft/backends/mklgpu/commit.cpp
@@ -25,6 +25,7 @@
 
 #include "oneapi/mkl/types.hpp"
 #include "oneapi/mkl/exceptions.hpp"
+#include "oneapi/mkl/detail/backends.hpp"
 
 #include "oneapi/mkl/dft/detail/commit_impl.hpp"
 #include "oneapi/mkl/dft/detail/types_impl.hpp"
@@ -59,7 +60,7 @@ private:
 
 public:
     commit_derived_impl(sycl::queue queue, dft::detail::dft_values<prec, dom> config_values)
-            : oneapi::mkl::dft::detail::commit_impl(queue),
+            : oneapi::mkl::dft::detail::commit_impl(queue, backend::mklgpu),
               handle(config_values.dimensions) {
         set_value(handle, config_values);
         // MKLGPU does not throw an informative exception for the following:
@@ -76,6 +77,10 @@ public:
             // Catching the real MKL exception causes headaches with naming.
             throw mkl::exception("DFT", "commit", mkl_exception.what());
         }
+    }
+
+    virtual void* get_handle() override {
+        return &handle;
     }
 
     virtual ~commit_derived_impl() override {}

--- a/src/dft/backends/mklgpu/forward.cpp
+++ b/src/dft/backends/mklgpu/forward.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2022 Intel Corporation
+* Copyright 2022 Codeplay Software Ltd.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+#include <type_traits>
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
 #else
@@ -24,185 +25,172 @@
 #endif
 
 #include "oneapi/mkl/types.hpp"
+#include "oneapi/mkl/exceptions.hpp"
 
 #include "oneapi/mkl/dft/detail/mklgpu/onemkl_dft_mklgpu.hpp"
+#include "oneapi/mkl/dft/detail/types_impl.hpp"
+#include "oneapi/mkl/dft/detail/descriptor_impl.hpp"
+
+#include "dft/backends/mklgpu/mklgpu_helpers.hpp"
+
+// MKLGPU header
+#include "oneapi/mkl/dfti.hpp"
+
+/**
+Note that in this file, the Intel MKL-GPU library's interface mirrors the interface
+of this OneMKL library. Consequently, the types under dft::TYPE are closed-source MKL types, 
+and types under dft::detail::TYPE are from this library.
+**/
 
 namespace oneapi {
 namespace mkl {
 namespace dft {
 namespace mklgpu {
-
-void compute_forward_buffer_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                      sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                      sycl::buffer<std::complex<float>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                      sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                      sycl::buffer<std::complex<double>, 1> &inout) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-
-void compute_forward_buffer_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                            sycl::buffer<float, 1> &inout_re,
-                                            sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_inplace_split_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                            sycl::buffer<float, 1> &inout_re,
-                                            sycl::buffer<float, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                            sycl::buffer<double, 1> &inout_re,
-                                            sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_inplace_split_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                            sycl::buffer<double, 1> &inout_re,
-                                            sycl::buffer<double, 1> &inout_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
+namespace detail {
+/// Forward a MKLGPU DFT call to the backend, checking that the commit impl is valid.
+/// Assumes backend descriptor values match those of the frontend.
+template <dft::detail::precision prec, dft::detail::domain dom, typename... ArgTs>
+inline auto compute_forward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&... args) {
+    using mklgpu_desc_t = dft::descriptor<to_mklgpu(prec), to_mklgpu(dom)>;
+    using commit_t = dft::detail::commit_impl;
+    auto commit_handle = dft::detail::get_commit(desc);
+    if (commit_handle == nullptr || commit_handle->get_backend() != backend::mklgpu) {
+        throw mkl::invalid_argument("DFT", "compute_forward",
+                                    "DFT descriptor has not been commited for MKLGPU");
+    }
+    auto mklgpu_desc = reinterpret_cast<mklgpu_desc_t *>(commit_handle->get_handle());
+    int commit_status{ DFTI_UNCOMMITTED };
+    mklgpu_desc->get_value(dft::config_param::COMMIT_STATUS, &commit_status);
+    if (commit_status != DFTI_COMMITTED) {
+        throw mkl::invalid_argument("DFT", "compute_forward",
+                                    "MKLGPU DFT descriptor was not successfully committed.");
+    }
+    return dft::compute_forward(*mklgpu_desc, std::forward<ArgTs>(args)...);
 }
 
-void compute_forward_buffer_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                         sycl::buffer<float, 1> &in,
-                                         sycl::buffer<std::complex<float>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
+/// Throw an mkl::invalid_argument if the runtime param in the descriptor does not match
+/// the expected value.
+template <dft::detail::config_param Param, dft::detail::config_value Expected, typename DescT>
+inline auto expect_config(DescT &desc, const char *message) {
+    dft::detail::config_value actual{ 0 };
+    desc.get_value(Param, &actual);
+    if (actual != Expected) {
+        throw mkl::invalid_argument("DFT", "compute_forward", message);
+    }
 }
-void compute_forward_buffer_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                         sycl::buffer<std::complex<float>, 1> &in,
-                                         sycl::buffer<std::complex<float>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                         sycl::buffer<double, 1> &in,
-                                         sycl::buffer<std::complex<double>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                         sycl::buffer<std::complex<double>, 1> &in,
-                                         sycl::buffer<std::complex<double>, 1> &out) {
-    throw std::runtime_error("Not implemented for mklgpu");
+} // namespace detail
+
+// BUFFER version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout) {
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    return detail::compute_forward(desc, inout);
 }
 
-void compute_forward_buffer_outofplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                               sycl::buffer<float, 1> &in_re,
-                                               sycl::buffer<float, 1> &in_im,
-                                               sycl::buffer<float, 1> &out_re,
-                                               sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_outofplace_split_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                               sycl::buffer<float, 1> &in_re,
-                                               sycl::buffer<float, 1> &in_im,
-                                               sycl::buffer<float, 1> &out_re,
-                                               sycl::buffer<float, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_outofplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                               sycl::buffer<double, 1> &in_re,
-                                               sycl::buffer<double, 1> &in_im,
-                                               sycl::buffer<double, 1> &out_re,
-                                               sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-void compute_forward_buffer_outofplace_split_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                               sycl::buffer<double, 1> &in_re,
-                                               sycl::buffer<double, 1> &in_im,
-                                               sycl::buffer<double, 1> &out_re,
-                                               sycl::buffer<double, 1> &out_im) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
+                                   sycl::buffer<data_type, 1> &inout_im) {
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    return detail::compute_forward(desc, inout_re, inout_im);
 }
 
-sycl::event compute_forward_usm_inplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                          std::complex<float> *inout,
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in,
+                                   sycl::buffer<output_type, 1> &out) {
+    if constexpr (!std::is_same_v<input_type, output_type>) {
+        throw mkl::unimplemented(
+            "DFT", "compute_forward",
+            "MKLGPU does not support out-of-place FFT with different input and output types.");
+    }
+    else {
+        detail::expect_config<dft::detail::config_param::PLACEMENT,
+                              dft::detail::config_value::NOT_INPLACE>(
+            desc, "Unexpected value for placement");
+        return detail::compute_forward(desc, in, out);
+    }
+}
+
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<input_type, 1> &in_re,
+                                   sycl::buffer<input_type, 1> &in_im,
+                                   sycl::buffer<output_type, 1> &out_re,
+                                   sycl::buffer<output_type, 1> &out_im) {
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    throw oneapi::mkl::unimplemented(
+        "DFT", "compute_forward(desc, in_re, in_im, out_re, out_im)",
+        "MKLGPU does not support out-of-place FFT with real-real complex storage.");
+}
+
+//USM version
+
+//In-place transform
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout,
                                           const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_inplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                          std::complex<float> *inout,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_inplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                          std::complex<double> *inout,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_inplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                          std::complex<double> *inout,
-                                          const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    return detail::compute_forward(desc, inout, dependencies);
 }
 
-sycl::event compute_forward_usm_inplace_split_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                                float *inout_re, float *inout_im,
-                                                const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_inplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *inout_re, float *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_inplace_split_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                                double *inout_re, double *inout_im,
-                                                const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_inplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *inout_re, double *inout_im,
-    const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename data_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout_re,
+                                          data_type *inout_im,
+                                          const std::vector<sycl::event> &dependencies) {
+    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
+        desc, "Unexpected value for placement");
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    return detail::compute_forward(desc, inout_re, inout_im, dependencies);
 }
 
-sycl::event compute_forward_usm_outofplace_f(descriptor<precision::SINGLE, domain::REAL> &desc,
-                                             float *in, std::complex<float> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_outofplace_c(descriptor<precision::SINGLE, domain::COMPLEX> &desc,
-                                             std::complex<float> *in, std::complex<float> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_outofplace_d(descriptor<precision::DOUBLE, domain::REAL> &desc,
-                                             double *in, std::complex<double> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_outofplace_z(descriptor<precision::DOUBLE, domain::COMPLEX> &desc,
-                                             std::complex<double> *in, std::complex<double> *out,
-                                             const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//Out-of-place transform
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in, output_type *out,
+                                          const std::vector<sycl::event> &dependencies) {
+    if constexpr (!std::is_same_v<input_type, output_type>) {
+        throw mkl::unimplemented(
+            "DFT", "compute_forward",
+            "MKLGPU does not support out-of-place FFT with different input and output types.");
+    }
+    else {
+        // Check: inplace, complex storage
+        detail::expect_config<dft::detail::config_param::PLACEMENT,
+                              dft::detail::config_value::NOT_INPLACE>(
+            desc, "Unexpected value for placement");
+        return detail::compute_forward(desc, in, out, dependencies);
+    }
 }
 
-sycl::event compute_forward_usm_outofplace_split_f(
-    descriptor<precision::SINGLE, domain::REAL> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
+//Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format
+template <typename descriptor_type, typename input_type, typename output_type>
+ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, input_type *in_re,
+                                          input_type *in_im, output_type *out_re,
+                                          output_type *out_im,
+                                          const std::vector<sycl::event> &dependencies) {
+    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
+                          dft::detail::config_value::REAL_REAL>(
+        desc, "Unexpected value for complex storage");
+    throw oneapi::mkl::unimplemented(
+        "DFT", "compute_forward(desc, in_re, in_im, out_re, out_im, deps)",
+        "MKLGPU does not support out-of-place FFT with real-real complex storage.");
 }
-sycl::event compute_forward_usm_outofplace_split_c(
-    descriptor<precision::SINGLE, domain::COMPLEX> &desc, float *in_re, float *in_im, float *out_re,
-    float *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_outofplace_split_d(
-    descriptor<precision::DOUBLE, domain::REAL> &desc, double *in_re, double *in_im, double *out_re,
-    double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
-sycl::event compute_forward_usm_outofplace_split_z(
-    descriptor<precision::DOUBLE, domain::COMPLEX> &desc, double *in_re, double *in_im,
-    double *out_re, double *out_im, const std::vector<sycl::event> &dependencies) {
-    throw std::runtime_error("Not implemented for mklgpu");
-}
+
+// Template function instantiations
+#include "dft/backends/backend_forward_instantiations.cxx"
 
 } // namespace mklgpu
 } // namespace dft

--- a/src/dft/backends/mklgpu/mkl_dft_gpu_wrappers.cpp
+++ b/src/dft/backends/mklgpu/mkl_dft_gpu_wrappers.cpp
@@ -21,9 +21,9 @@
 #include "dft/function_table.hpp"
 
 #define WRAPPER_VERSION 1
+#define BACKEND         mklgpu
 
-extern "C" dft_function_table_t mkl_dft_table = { WRAPPER_VERSION,
-                                                  oneapi::mkl::dft::mklgpu::create_commit,
-                                                  oneapi::mkl::dft::mklgpu::create_commit,
-                                                  oneapi::mkl::dft::mklgpu::create_commit,
-                                                  oneapi::mkl::dft::mklgpu::create_commit };
+extern "C" dft_function_table_t mkl_dft_table = {
+    WRAPPER_VERSION,
+#include "dft/backends/backend_wrappers.cxx"
+};

--- a/src/dft/dft_loader.cpp
+++ b/src/dft/dft_loader.cpp
@@ -18,6 +18,8 @@
 *******************************************************************************/
 
 #include "oneapi/mkl/dft/detail/dft_loader.hpp"
+#include "oneapi/mkl/dft/forward.hpp"
+#include "oneapi/mkl/dft/backward.hpp"
 
 #include "function_table_initializer.hpp"
 #include "dft/function_table.hpp"
@@ -60,6 +62,184 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
 }
 
 } // namespace detail
+
+#define ONEAPI_MKL_DFT_SIGNATURES(EXT, PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)                \
+                                                                                                        \
+    /*Buffer version*/                                                                                  \
+                                                                                                        \
+    /*In-place transform*/                                                                              \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>(          \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_FORWARD, 1> & inout) {        \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_forward_buffer_inplace_##EXT(desc, inout);                                         \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(             \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & inout_re,          \
+        sycl::buffer<T_REAL, 1> & inout_im) {                                                           \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_forward_buffer_inplace_split_##EXT(desc, inout_re, inout_im);                      \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform*/                                                                          \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void                                                                                  \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>(                 \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_FORWARD, 1> & in,             \
+        sycl::buffer<T_BACKWARD, 1> & out) {                                                            \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_forward_buffer_outofplace_##EXT(desc, in, out);                                    \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void                                                                                  \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                        \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & in_re,             \
+        sycl::buffer<T_REAL, 1> & in_im, sycl::buffer<T_REAL, 1> & out_re,                              \
+        sycl::buffer<T_REAL, 1> & out_im) {                                                             \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_forward_buffer_outofplace_split_##EXT(desc, in_re, in_im, out_re, out_im);         \
+    }                                                                                                   \
+                                                                                                        \
+    /*USM version*/                                                                                     \
+                                                                                                        \
+    /*In-place transform*/                                                                              \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>(                             \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * inout,                           \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_forward_usm_inplace_##EXT(desc, inout, dependencies);                              \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(      \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re, T_REAL * inout_im,        \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_forward_usm_inplace_split_##EXT(desc, inout_re, inout_im, dependencies);           \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform*/                                                                          \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>(                 \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * in, T_BACKWARD * out,            \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_forward_usm_outofplace_##EXT(desc, in, out, dependencies);                         \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                        \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re, T_REAL * in_im,              \
+        T_REAL * out_re, T_REAL * out_im, const std::vector<sycl::event>& dependencies) {               \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_forward_usm_outofplace_split_##EXT(desc, in_re, in_im, out_re, out_im,             \
+                                                        dependencies);                                  \
+    }                                                                                                   \
+                                                                                                        \
+    /*Buffer version*/                                                                                  \
+                                                                                                        \
+    /*In-place transform*/                                                                              \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>(        \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_BACKWARD, 1> & inout) {       \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_backward_buffer_inplace_##EXT(desc, inout);                                        \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(            \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & inout_re,          \
+        sycl::buffer<T_REAL, 1> & inout_im) {                                                           \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_backward_buffer_inplace_split_##EXT(desc, inout_re, inout_im);                     \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform*/                                                                          \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void                                                                                  \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>(                \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_BACKWARD, 1> & in,            \
+        sycl::buffer<T_FORWARD, 1> & out) {                                                             \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_backward_buffer_outofplace_##EXT(desc, in, out);                                   \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void                                                                                  \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                       \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & in_re,             \
+        sycl::buffer<T_REAL, 1> & in_im, sycl::buffer<T_REAL, 1> & out_re,                              \
+        sycl::buffer<T_REAL, 1> & out_im) {                                                             \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_backward_buffer_outofplace_split_##EXT(desc, in_re, in_im, out_re, out_im);        \
+    }                                                                                                   \
+                                                                                                        \
+    /*USM version*/                                                                                     \
+                                                                                                        \
+    /*In-place transform*/                                                                              \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>(                           \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,                          \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_backward_usm_inplace_##EXT(desc, inout, dependencies);                             \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(                               \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re, T_REAL * inout_im,        \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_backward_usm_inplace_split_##EXT(desc, inout_re, inout_im, dependencies);          \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform*/                                                                          \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>(                \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in, T_FORWARD * out,            \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_backward_usm_outofplace_##EXT(desc, in, out, dependencies);                        \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                       \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re, T_REAL * in_im,              \
+        T_REAL * out_re, T_REAL * out_im, const std::vector<sycl::event>& dependencies) {               \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_backward_usm_outofplace_split_##EXT(desc, in_re, in_im, out_re, out_im,            \
+                                                         dependencies);                                 \
+    }
+
+ONEAPI_MKL_DFT_SIGNATURES(f, dft::detail::precision::SINGLE, dft::detail::domain::REAL, float,
+                          float, std::complex<float>)
+ONEAPI_MKL_DFT_SIGNATURES(c, dft::detail::precision::SINGLE, dft::detail::domain::COMPLEX, float,
+                          std::complex<float>, std::complex<float>)
+ONEAPI_MKL_DFT_SIGNATURES(d, dft::detail::precision::DOUBLE, dft::detail::domain::REAL, double,
+                          double, std::complex<double>)
+ONEAPI_MKL_DFT_SIGNATURES(z, dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX, double,
+                          std::complex<double>, std::complex<double>)
+#undef ONEAPI_MKL_DFT_SIGNATURES
+
 } // namespace dft
 } // namespace mkl
 } // namespace oneapi

--- a/src/dft/function_table.hpp
+++ b/src/dft/function_table.hpp
@@ -47,6 +47,75 @@ typedef struct {
     oneapi::mkl::dft::detail::commit_impl* (*create_commit_sycl_dr)(
         oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::DOUBLE,
                                      oneapi::mkl::dft::domain::REAL>& desc);
+
+#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(EXT, PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD) \
+    void (*compute_forward_buffer_inplace_##EXT)(                                                \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_FORWARD, 1> & inout);                                                     \
+    void (*compute_forward_buffer_inplace_split_##EXT)(                                          \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                 \
+    void (*compute_forward_buffer_outofplace_##EXT)(                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_FORWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                     \
+    void (*compute_forward_buffer_outofplace_split_##EXT)(                                       \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                        \
+        sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                     \
+    sycl::event (*compute_forward_usm_inplace_##EXT)(                                            \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * inout,       \
+        const std::vector<sycl::event>& dependencies);                                           \
+    sycl::event (*compute_forward_usm_inplace_split_##EXT)(                                      \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,       \
+        T_REAL * inout_im, const std::vector<sycl::event>& dependencies);                        \
+    sycl::event (*compute_forward_usm_outofplace_##EXT)(                                         \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * in,          \
+        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                         \
+    sycl::event (*compute_forward_usm_outofplace_split_##EXT)(                                   \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,          \
+        T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                        \
+        const std::vector<sycl::event>& dependencies);                                           \
+    void (*compute_backward_buffer_inplace_##EXT)(                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_BACKWARD, 1> & inout);                                                    \
+    void (*compute_backward_buffer_inplace_split_##EXT)(                                         \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                 \
+    void (*compute_backward_buffer_outofplace_##EXT)(                                            \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_FORWARD, 1> & out);                     \
+    void (*compute_backward_buffer_outofplace_split_##EXT)(                                      \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                        \
+        sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                     \
+    sycl::event (*compute_backward_usm_inplace_##EXT)(                                           \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,      \
+        const std::vector<sycl::event>& dependencies);                                           \
+    sycl::event (*compute_backward_usm_inplace_split_##EXT)(                                     \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,       \
+        T_REAL * inout_im, const std::vector<sycl::event>& dependencies);                        \
+    sycl::event (*compute_backward_usm_outofplace_##EXT)(                                        \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,         \
+        T_FORWARD * out, const std::vector<sycl::event>& dependencies);                          \
+    sycl::event (*compute_backward_usm_outofplace_split_##EXT)(                                  \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,          \
+        T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                        \
+        const std::vector<sycl::event>& dependencies);
+
+    ONEAPI_MKL_DFT_BACKEND_SIGNATURES(f, oneapi::mkl::dft::detail::precision::SINGLE,
+                                      oneapi::mkl::dft::detail::domain::REAL, float, float,
+                                      std::complex<float>)
+    ONEAPI_MKL_DFT_BACKEND_SIGNATURES(c, oneapi::mkl::dft::detail::precision::SINGLE,
+                                      oneapi::mkl::dft::detail::domain::COMPLEX, float,
+                                      std::complex<float>, std::complex<float>)
+    ONEAPI_MKL_DFT_BACKEND_SIGNATURES(d, oneapi::mkl::dft::detail::precision::DOUBLE,
+                                      oneapi::mkl::dft::detail::domain::REAL, double, double,
+                                      std::complex<double>)
+    ONEAPI_MKL_DFT_BACKEND_SIGNATURES(z, oneapi::mkl::dft::detail::precision::DOUBLE,
+                                      oneapi::mkl::dft::detail::domain::COMPLEX, double,
+                                      std::complex<double>, std::complex<double>)
+
+#undef ONEAPI_MKL_DFT_BACKEND_SIGNATURES
 } dft_function_table_t;
 
 #endif //_DFT_FUNCTION_TABLE_HPP_


### PR DESCRIPTION
* Rename compute_forward/backward functions to match spec for compile-time dispatch.
* Factor common code into shared files.
* Add previously removed run-time compute-forward/backward implemention.
* Initial implementation of MKLGPU compute forward / compute backward
  * Missing some MKLGPU signatures (more to be added in later commit).
  * Untested.

# Description

Please include a summary of the change. Please also include relevant
motivation and context. See
[contribution guidelines](https://github.com/oneapi-src/oneMKL/blob/master/CONTRIBUTING.md)
for more details. If the change fixes an issue not documented in the project's
Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (GitHub issue)

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [ ] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
