### PR TITLE
[DFT] Add additional instantiations for compute forward/backward

### DIFF
--- a/src/dft/backends/backend_backward_instantiations.cxx
+++ b/src/dft/backends/backend_backward_instantiations.cxx
@@ -27,31 +27,45 @@
 #define DESC_CD       dft::detail::descriptor<PREC_D, DOM_COMPLEX>
 #define DEPENDS_VEC_T const std::vector<sycl::event> &
 
-#define ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)       \
-    /* Buffer API */                                                                          \
-    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T>(                   \
-        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &);                                     \
-    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>(        \
-        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &, sycl::buffer<FORWARD_T> &);          \
-    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T>(                       \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                 \
-    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(               \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                  \
-        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                      \
-                                                                                              \
-    /* USM API */                                                                             \
-    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T>(            \
-        DESCRIPTOR_T & desc, BACKWARD_T *, DEPENDS_VEC_T);                                    \
-    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>( \
-        DESCRIPTOR_T & desc, BACKWARD_T *, FORWARD_T *, DEPENDS_VEC_T);                       \
-    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T>(                \
-        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                              \
-    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(        \
+#define ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)         \
+    /* Buffer API */                                                                            \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T>(DESCRIPTOR_T & desc,     \
+                                                                       sycl::buffer<REAL_T> &); \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T>(                     \
+        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &);                                       \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>(          \
+        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &, sycl::buffer<FORWARD_T> &);            \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T>(                         \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                   \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                    \
+        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                        \
+                                                                                                \
+    /* USM API */                                                                               \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T>(                  \
+        DESCRIPTOR_T & desc, REAL_T *, DEPENDS_VEC_T);                                          \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T>(              \
+        DESCRIPTOR_T & desc, BACKWARD_T *, DEPENDS_VEC_T);                                      \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>(   \
+        DESCRIPTOR_T & desc, BACKWARD_T *, FORWARD_T *, DEPENDS_VEC_T);                         \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T>(                  \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                                \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
         DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, DEPENDS_VEC_T);
 
+#define ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T) \
+    /* Buffer API */                                                                              \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T, BACKWARD_T>(           \
+        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &, sycl::buffer<BACKWARD_T> &);             \
+    /* USM API */                                                                                 \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T, BACKWARD_T>(    \
+        DESCRIPTOR_T & desc, BACKWARD_T *, BACKWARD_T *, DEPENDS_VEC_T);
+
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_RF, float, float, std::complex<float>)
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESC_RF, float, float, std::complex<float>)
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_CF, float, std::complex<float>, std::complex<float>)
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_RD, double, double, std::complex<double>)
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESC_RD, double, double, std::complex<double>)
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_CD, double, std::complex<double>, std::complex<double>)
 
 #undef ONEMKL_DFT_BACKWARD_INSTANTIATIONS

--- a/src/dft/backends/backend_backward_instantiations.cxx
+++ b/src/dft/backends/backend_backward_instantiations.cxx
@@ -53,19 +53,19 @@
     template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
         DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, DEPENDS_VEC_T);
 
-#define ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T) \
-    /* Buffer API */                                                                              \
-    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, BACKWARD_T, BACKWARD_T>(           \
-        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &, sycl::buffer<BACKWARD_T> &);             \
-    /* USM API */                                                                                 \
-    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T, BACKWARD_T>(    \
-        DESCRIPTOR_T & desc, BACKWARD_T *, BACKWARD_T *, DEPENDS_VEC_T);
+#define ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESCRIPTOR_T, COMPLEX_T)                \
+    /* Buffer API */                                                                         \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, COMPLEX_T, COMPLEX_T>(        \
+        DESCRIPTOR_T & desc, sycl::buffer<COMPLEX_T> &, sycl::buffer<COMPLEX_T> &);          \
+    /* USM API */                                                                            \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, COMPLEX_T, COMPLEX_T>( \
+        DESCRIPTOR_T & desc, COMPLEX_T *, COMPLEX_T *, DEPENDS_VEC_T);
 
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_RF, float, float, std::complex<float>)
-ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESC_RF, float, float, std::complex<float>)
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESC_RF, std::complex<float>)
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_CF, float, std::complex<float>, std::complex<float>)
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_RD, double, double, std::complex<double>)
-ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESC_RD, double, double, std::complex<double>)
+ONEMKL_DFT_BACKWARD_INSTANTIATIONS_REAL_ONLY(DESC_RD, std::complex<double>)
 ONEMKL_DFT_BACKWARD_INSTANTIATIONS(DESC_CD, double, std::complex<double>, std::complex<double>)
 
 #undef ONEMKL_DFT_BACKWARD_INSTANTIATIONS

--- a/src/dft/backends/backend_backward_instantiations.cxx
+++ b/src/dft/backends/backend_backward_instantiations.cxx
@@ -38,6 +38,8 @@
     template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T>(                         \
         DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                   \
     template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                   \
+    template ONEMKL_EXPORT void compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
         DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                    \
         sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                        \
                                                                                                 \
@@ -49,6 +51,8 @@
     template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, BACKWARD_T, FORWARD_T>(   \
         DESCRIPTOR_T & desc, BACKWARD_T *, FORWARD_T *, DEPENDS_VEC_T);                         \
     template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T>(                  \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                                \
+    template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
         DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                                \
     template ONEMKL_EXPORT sycl::event compute_backward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
         DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, DEPENDS_VEC_T);

--- a/src/dft/backends/backend_forward_instantiations.cxx
+++ b/src/dft/backends/backend_forward_instantiations.cxx
@@ -38,6 +38,8 @@
     template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(                         \
         DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                  \
     template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                  \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
         DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                   \
         sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                       \
                                                                                                \
@@ -49,6 +51,8 @@
     template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(   \
         DESCRIPTOR_T & desc, FORWARD_T *, BACKWARD_T *, DEPENDS_VEC_T);                        \
     template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                  \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                               \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
         DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                               \
     template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
         DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, DEPENDS_VEC_T);

--- a/src/dft/backends/backend_forward_instantiations.cxx
+++ b/src/dft/backends/backend_forward_instantiations.cxx
@@ -27,31 +27,45 @@
 #define DESC_CD       dft::detail::descriptor<PREC_D, DOM_COMPLEX>
 #define DEPENDS_VEC_T const std::vector<sycl::event> &
 
-#define ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)       \
-    /* Buffer API */                                                                         \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, FORWARD_T>(                    \
-        DESCRIPTOR_T & desc, sycl::buffer<FORWARD_T> &);                                     \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(        \
-        DESCRIPTOR_T & desc, sycl::buffer<FORWARD_T> &, sycl::buffer<BACKWARD_T> &);         \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(                       \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(               \
-        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                 \
-        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                     \
-                                                                                             \
-    /* USM API */                                                                            \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T>(             \
-        DESCRIPTOR_T & desc, FORWARD_T *, DEPENDS_VEC_T);                                    \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>( \
-        DESCRIPTOR_T & desc, FORWARD_T *, BACKWARD_T *, DEPENDS_VEC_T);                      \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                \
-        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                             \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(        \
+#define ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T)         \
+    /* Buffer API */                                                                           \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(DESCRIPTOR_T & desc,     \
+                                                                      sycl::buffer<REAL_T> &); \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, BACKWARD_T>(                     \
+        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &);                                      \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(          \
+        DESCRIPTOR_T & desc, sycl::buffer<FORWARD_T> &, sycl::buffer<BACKWARD_T> &);           \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T>(                         \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                  \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(                 \
+        DESCRIPTOR_T & desc, sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &,                   \
+        sycl::buffer<REAL_T> &, sycl::buffer<REAL_T> &);                                       \
+                                                                                               \
+    /* USM API */                                                                              \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                  \
+        DESCRIPTOR_T & desc, REAL_T *, DEPENDS_VEC_T);                                         \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, BACKWARD_T>(              \
+        DESCRIPTOR_T & desc, BACKWARD_T *, DEPENDS_VEC_T);                                     \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, FORWARD_T, BACKWARD_T>(   \
+        DESCRIPTOR_T & desc, FORWARD_T *, BACKWARD_T *, DEPENDS_VEC_T);                        \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T>(                  \
+        DESCRIPTOR_T & desc, REAL_T *, REAL_T *, DEPENDS_VEC_T);                               \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
         DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, DEPENDS_VEC_T);
 
+#define ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T) \
+    /* Buffer API */                                                                             \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, BACKWARD_T, BACKWARD_T>(           \
+        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &, sycl::buffer<BACKWARD_T> &);            \
+    /* USM API */                                                                                \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, BACKWARD_T, BACKWARD_T>(    \
+        DESCRIPTOR_T & desc, BACKWARD_T *, BACKWARD_T *, DEPENDS_VEC_T);
+
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_RF, float, float, std::complex<float>)
+ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESC_RF, float, float, std::complex<float>)
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_CF, float, std::complex<float>, std::complex<float>)
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_RD, double, double, std::complex<double>)
+ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESC_RD, double, double, std::complex<double>)
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_CD, double, std::complex<double>, std::complex<double>)
 
 #undef ONEMKL_DFT_FORWARD_INSTANTIATIONS

--- a/src/dft/backends/backend_forward_instantiations.cxx
+++ b/src/dft/backends/backend_forward_instantiations.cxx
@@ -53,19 +53,19 @@
     template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, REAL_T, REAL_T>(          \
         DESCRIPTOR_T & desc, REAL_T *, REAL_T *, REAL_T *, REAL_T *, DEPENDS_VEC_T);
 
-#define ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESCRIPTOR_T, REAL_T, FORWARD_T, BACKWARD_T) \
-    /* Buffer API */                                                                             \
-    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, BACKWARD_T, BACKWARD_T>(           \
-        DESCRIPTOR_T & desc, sycl::buffer<BACKWARD_T> &, sycl::buffer<BACKWARD_T> &);            \
-    /* USM API */                                                                                \
-    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, BACKWARD_T, BACKWARD_T>(    \
-        DESCRIPTOR_T & desc, BACKWARD_T *, BACKWARD_T *, DEPENDS_VEC_T);
+#define ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESCRIPTOR_T, COMPLEX_T)                \
+    /* Buffer API */                                                                        \
+    template ONEMKL_EXPORT void compute_forward<DESCRIPTOR_T, COMPLEX_T, COMPLEX_T>(        \
+        DESCRIPTOR_T & desc, sycl::buffer<COMPLEX_T> &, sycl::buffer<COMPLEX_T> &);         \
+    /* USM API */                                                                           \
+    template ONEMKL_EXPORT sycl::event compute_forward<DESCRIPTOR_T, COMPLEX_T, COMPLEX_T>( \
+        DESCRIPTOR_T & desc, COMPLEX_T *, COMPLEX_T *, DEPENDS_VEC_T);
 
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_RF, float, float, std::complex<float>)
-ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESC_RF, float, float, std::complex<float>)
+ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESC_RF, std::complex<float>)
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_CF, float, std::complex<float>, std::complex<float>)
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_RD, double, double, std::complex<double>)
-ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESC_RD, double, double, std::complex<double>)
+ONEMKL_DFT_FORWARD_INSTANTIATIONS_REAL_ONLY(DESC_RD, std::complex<double>)
 ONEMKL_DFT_FORWARD_INSTANTIATIONS(DESC_CD, double, std::complex<double>, std::complex<double>)
 
 #undef ONEMKL_DFT_FORWARD_INSTANTIATIONS

--- a/src/dft/backends/backend_wrappers.cxx
+++ b/src/dft/backends/backend_wrappers.cxx
@@ -41,42 +41,58 @@ oneapi::mkl::dft::BACKEND::create_commit,
 oneapi::mkl::dft::BACKEND::create_commit,
 oneapi::mkl::dft::BACKEND::create_commit,
 oneapi::mkl::dft::BACKEND::create_commit,
-#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)  \
-    /* Buffer API */                                                                         \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>,                 \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,     \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                     \
-        T_REAL>, /* USM API */                                                               \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>,                 \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,     \
-    oneapi::mkl::dft::BACKEND::compute_forward<                                              \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                     \
-        T_REAL>, /* Buffer API */                                                            \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,     \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,                     \
-        T_REAL>, /* USM API */                                                               \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                    \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,     \
-    oneapi::mkl::dft::BACKEND::compute_backward<                                             \
+#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)   \
+    /* Buffer API */                                                                          \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                 \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,      \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_BACKWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,  T_REAL>,            \
+    /* USM API */                                                                             \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                 \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,      \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_BACKWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
+    /* Buffer API */                                                                          \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                 \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,      \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_BACKWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
+    /* USM API */                                                                             \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>,                 \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,      \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_BACKWARD>,     \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,
 
 ONEAPI_MKL_DFT_BACKEND_SIGNATURES(oneapi::mkl::dft::detail::precision::SINGLE,

--- a/src/dft/backends/backend_wrappers.cxx
+++ b/src/dft/backends/backend_wrappers.cxx
@@ -52,6 +52,8 @@ oneapi::mkl::dft::BACKEND::create_commit,
     oneapi::mkl::dft::BACKEND::compute_forward<                                               \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,      \
     oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_BACKWARD>,     \
     oneapi::mkl::dft::BACKEND::compute_forward<                                               \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL,  T_REAL>,            \
@@ -64,6 +66,8 @@ oneapi::mkl::dft::BACKEND::create_commit,
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
     oneapi::mkl::dft::BACKEND::compute_forward<                                               \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD, T_BACKWARD>,      \
+    oneapi::mkl::dft::BACKEND::compute_forward<                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
     oneapi::mkl::dft::BACKEND::compute_forward<                                               \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_BACKWARD>,     \
     oneapi::mkl::dft::BACKEND::compute_forward<                                               \
@@ -78,6 +82,8 @@ oneapi::mkl::dft::BACKEND::create_commit,
     oneapi::mkl::dft::BACKEND::compute_backward<                                              \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,      \
     oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_BACKWARD>,     \
     oneapi::mkl::dft::BACKEND::compute_backward<                                              \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
@@ -90,6 +96,8 @@ oneapi::mkl::dft::BACKEND::create_commit,
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>,                     \
     oneapi::mkl::dft::BACKEND::compute_backward<                                              \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_FORWARD>,      \
+    oneapi::mkl::dft::BACKEND::compute_backward<                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>,             \
     oneapi::mkl::dft::BACKEND::compute_backward<                                              \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD, T_BACKWARD>,     \
     oneapi::mkl::dft::BACKEND::compute_backward<                                              \

--- a/src/dft/backends/mklgpu/backward.cpp
+++ b/src/dft/backends/mklgpu/backward.cpp
@@ -58,6 +58,9 @@ inline auto compute_backward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&.
         throw mkl::invalid_argument("DFT", "compute_backward",
                                     "MKLGPU DFT descriptor was not successfully committed.");
     }
+    // The MKLGPU backend's iterface contains fewer function signatures than in this
+    // open-source library. Consequently, it is not required to forward template arguments
+    // to resolve to the correct function.
     return dft::compute_backward(*mklgpu_desc, std::forward<ArgTs>(args)...);
 }
 
@@ -87,12 +90,8 @@ ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_typ
 template <typename descriptor_type, typename data_type>
 ONEMKL_EXPORT void compute_backward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
                                     sycl::buffer<data_type, 1> &inout_im) {
-    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
-        desc, "Unexpected value for placement");
-    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
-                          dft::detail::config_value::REAL_REAL>(
-        desc, "Unexpected value for complex storage");
-    return detail::compute_backward(desc, inout_re, inout_im);
+    throw mkl::unimplemented("DFT", "compute_backward",
+                             "MKLGPU does not support compute_backward(desc, inout_re, inout_im).");
 }
 
 //Out-of-place transform
@@ -142,12 +141,8 @@ template <typename descriptor_type, typename data_type>
 ONEMKL_EXPORT sycl::event compute_backward(descriptor_type &desc, data_type *inout_re,
                                            data_type *inout_im,
                                            const std::vector<sycl::event> &dependencies) {
-    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
-        desc, "Unexpected value for placement");
-    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
-                          dft::detail::config_value::REAL_REAL>(
-        desc, "Unexpected value for complex storage");
-    return detail::compute_backward(desc, inout_re, inout_im, dependencies);
+    throw mkl::unimplemented("DFT", "compute_backward",
+                             "MKLGPU does not support compute_backward(desc, inout_re, inout_im).");
 }
 
 //Out-of-place transform

--- a/src/dft/backends/mklgpu/forward.cpp
+++ b/src/dft/backends/mklgpu/forward.cpp
@@ -65,6 +65,9 @@ inline auto compute_forward(dft::detail::descriptor<prec, dom> &desc, ArgTs &&..
         throw mkl::invalid_argument("DFT", "compute_forward",
                                     "MKLGPU DFT descriptor was not successfully committed.");
     }
+    // The MKLGPU backend's iterface contains fewer function signatures than in this
+    // open-source library. Consequently, it is not required to forward template arguments
+    // to resolve to the correct function.
     return dft::compute_forward(*mklgpu_desc, std::forward<ArgTs>(args)...);
 }
 
@@ -94,12 +97,8 @@ ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type
 template <typename descriptor_type, typename data_type>
 ONEMKL_EXPORT void compute_forward(descriptor_type &desc, sycl::buffer<data_type, 1> &inout_re,
                                    sycl::buffer<data_type, 1> &inout_im) {
-    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
-        desc, "Unexpected value for placement");
-    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
-                          dft::detail::config_value::REAL_REAL>(
-        desc, "Unexpected value for complex storage");
-    return detail::compute_forward(desc, inout_re, inout_im);
+    throw mkl::unimplemented("DFT", "compute_forward",
+                             "MKLGPU does not support compute_forward(desc, inout_re, inout_im).");
 }
 
 //Out-of-place transform
@@ -149,12 +148,8 @@ template <typename descriptor_type, typename data_type>
 ONEMKL_EXPORT sycl::event compute_forward(descriptor_type &desc, data_type *inout_re,
                                           data_type *inout_im,
                                           const std::vector<sycl::event> &dependencies) {
-    detail::expect_config<dft::detail::config_param::PLACEMENT, dft::detail::config_value::INPLACE>(
-        desc, "Unexpected value for placement");
-    detail::expect_config<dft::detail::config_param::COMPLEX_STORAGE,
-                          dft::detail::config_value::REAL_REAL>(
-        desc, "Unexpected value for complex storage");
-    return detail::compute_forward(desc, inout_re, inout_im, dependencies);
+    throw mkl::unimplemented("DFT", "compute_forward",
+                             "MKLGPU does not support compute_forward(desc, inout_re, inout_im).");
 }
 
 //Out-of-place transform

--- a/src/dft/dft_loader.cpp
+++ b/src/dft/dft_loader.cpp
@@ -102,6 +102,16 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
             .compute_forward_buffer_outofplace_##EXT(desc, in, out);                                    \
     }                                                                                                   \
                                                                                                         \
+    /*Out-of-place transform - real*/                                                                   \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void                                                                                  \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                        \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & in,                \
+        sycl::buffer<T_REAL, 1> & out) {                                                                \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_forward_buffer_outofplace_real_##EXT(desc, in, out);                               \
+    }                                                                                                   \
+                                                                                                        \
     /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
     template <>                                                                                         \
     ONEMKL_EXPORT void                                                                                  \
@@ -153,6 +163,16 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
             .compute_forward_usm_outofplace_##EXT(desc, in, out, dependencies);                         \
     }                                                                                                   \
                                                                                                         \
+    /*Out-of-place transform*/                                                                          \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                        \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in, T_REAL * out,                   \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_forward_usm_outofplace_real_##EXT(desc, in, out, dependencies);                    \
+    }                                                                                                   \
+                                                                                                        \
     /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
     template <>                                                                                         \
     ONEMKL_EXPORT sycl::event                                                                           \
@@ -199,6 +219,16 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
         sycl::buffer<T_FORWARD, 1> & out) {                                                             \
         detail::function_tables[get_device_id(desc.get_queue())]                                        \
             .compute_backward_buffer_outofplace_##EXT(desc, in, out);                                   \
+    }                                                                                                   \
+                                                                                                        \
+    /*Out-of-place transform - real*/                                                                   \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void                                                                                  \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                       \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & in,                \
+        sycl::buffer<T_REAL, 1> & out) {                                                                \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_backward_buffer_outofplace_real_##EXT(desc, in, out);                              \
     }                                                                                                   \
                                                                                                         \
     /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
@@ -254,6 +284,16 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
             .compute_backward_usm_outofplace_##EXT(desc, in, out, dependencies);                        \
     }                                                                                                   \
                                                                                                         \
+    /*Out-of-place transform - real*/                                                                   \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL, T_REAL>(                       \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in, T_REAL * out,                   \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_backward_usm_outofplace_real_##EXT(desc, in, out, dependencies);                   \
+    }                                                                                                   \
+                                                                                                        \
     /*Out-of-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/ \
     template <>                                                                                         \
     ONEMKL_EXPORT sycl::event                                                                           \
@@ -265,12 +305,57 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
                                                          dependencies);                                 \
     }
 
+// Signatures with forward_t=complex, backwards_t=complex are already instantiated for complex domain
+// but not real domain.
+#define ONEAPI_MKL_DFT_REAL_ONLY_SIGNATURES(EXT, PRECISION, T_COMPLEX)                            \
+    /*Out-of-place transform - complex*/                                                          \
+    template <>                                                                                   \
+    ONEMKL_EXPORT void                                                                            \
+    compute_forward<dft::detail::descriptor<PRECISION, domain::REAL>, T_COMPLEX, T_COMPLEX>(      \
+        dft::detail::descriptor<PRECISION, domain::REAL> & desc, sycl::buffer<T_COMPLEX, 1> & in, \
+        sycl::buffer<T_COMPLEX, 1> & out) {                                                       \
+        detail::function_tables[get_device_id(desc.get_queue())]                                  \
+            .compute_forward_buffer_outofplace_complex_##EXT(desc, in, out);                      \
+    }                                                                                             \
+                                                                                                  \
+    /*Out-of-place transform - complex*/                                                          \
+    template <>                                                                                   \
+    ONEMKL_EXPORT sycl::event                                                                     \
+    compute_forward<dft::detail::descriptor<PRECISION, domain::REAL>, T_COMPLEX, T_COMPLEX>(      \
+        dft::detail::descriptor<PRECISION, domain::REAL> & desc, T_COMPLEX * in, T_COMPLEX * out, \
+        const std::vector<sycl::event>& dependencies) {                                           \
+        return detail::function_tables[get_device_id(desc.get_queue())]                           \
+            .compute_forward_usm_outofplace_complex_##EXT(desc, in, out, dependencies);           \
+    }                                                                                             \
+                                                                                                  \
+    /*Out-of-place transform - complex*/                                                          \
+    template <>                                                                                   \
+    ONEMKL_EXPORT void                                                                            \
+    compute_backward<dft::detail::descriptor<PRECISION, domain::REAL>, T_COMPLEX, T_COMPLEX>(     \
+        dft::detail::descriptor<PRECISION, domain::REAL> & desc, sycl::buffer<T_COMPLEX, 1> & in, \
+        sycl::buffer<T_COMPLEX, 1> & out) {                                                       \
+        detail::function_tables[get_device_id(desc.get_queue())]                                  \
+            .compute_backward_buffer_outofplace_complex_##EXT(desc, in, out);                     \
+    }                                                                                             \
+                                                                                                  \
+    /*Out-of-place transform - complex*/                                                          \
+    template <>                                                                                   \
+    ONEMKL_EXPORT sycl::event                                                                     \
+    compute_backward<dft::detail::descriptor<PRECISION, domain::REAL>, T_COMPLEX, T_COMPLEX>(     \
+        dft::detail::descriptor<PRECISION, domain::REAL> & desc, T_COMPLEX * in, T_COMPLEX * out, \
+        const std::vector<sycl::event>& dependencies) {                                           \
+        return detail::function_tables[get_device_id(desc.get_queue())]                           \
+            .compute_backward_usm_outofplace_complex_##EXT(desc, in, out, dependencies);          \
+    }
+
 ONEAPI_MKL_DFT_SIGNATURES(f, dft::detail::precision::SINGLE, dft::detail::domain::REAL, float,
                           float, std::complex<float>)
+ONEAPI_MKL_DFT_REAL_ONLY_SIGNATURES(f, dft::detail::precision::SINGLE, std::complex<float>)
 ONEAPI_MKL_DFT_SIGNATURES(c, dft::detail::precision::SINGLE, dft::detail::domain::COMPLEX, float,
                           std::complex<float>, std::complex<float>)
 ONEAPI_MKL_DFT_SIGNATURES(d, dft::detail::precision::DOUBLE, dft::detail::domain::REAL, double,
                           double, std::complex<double>)
+ONEAPI_MKL_DFT_REAL_ONLY_SIGNATURES(d, dft::detail::precision::DOUBLE, std::complex<double>)
 ONEAPI_MKL_DFT_SIGNATURES(z, dft::detail::precision::DOUBLE, dft::detail::domain::COMPLEX, double,
                           std::complex<double>, std::complex<double>)
 #undef ONEAPI_MKL_DFT_SIGNATURES

--- a/src/dft/dft_loader.cpp
+++ b/src/dft/dft_loader.cpp
@@ -67,12 +67,20 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
                                                                                                         \
     /*Buffer version*/                                                                                  \
                                                                                                         \
-    /*In-place transform*/                                                                              \
+    /*In-place transform - real*/                                                                       \
     template <>                                                                                         \
-    ONEMKL_EXPORT void compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>(          \
-        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_FORWARD, 1> & inout) {        \
+    ONEMKL_EXPORT void compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(             \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & inout) {           \
         detail::function_tables[get_device_id(desc.get_queue())]                                        \
-            .compute_forward_buffer_inplace_##EXT(desc, inout);                                         \
+            .compute_forward_buffer_inplace_real_##EXT(desc, inout);                                    \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform - complex*/                                                                    \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>(         \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_BACKWARD, 1> & inout) {       \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_forward_buffer_inplace_complex_##EXT(desc, inout);                                 \
     }                                                                                                   \
                                                                                                         \
     /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
@@ -107,14 +115,23 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
                                                                                                         \
     /*USM version*/                                                                                     \
                                                                                                         \
-    /*In-place transform*/                                                                              \
+    /*In-place transform - real*/                                                                       \
     template <>                                                                                         \
-    ONEMKL_EXPORT sycl::event                                                                           \
-    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_FORWARD>(                             \
-        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * inout,                           \
+    ONEMKL_EXPORT sycl::event compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(      \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout,                              \
         const std::vector<sycl::event>& dependencies) {                                                 \
         return detail::function_tables[get_device_id(desc.get_queue())]                                 \
-            .compute_forward_usm_inplace_##EXT(desc, inout, dependencies);                              \
+            .compute_forward_usm_inplace_real_##EXT(desc, inout, dependencies);                         \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform - complex*/                                                                    \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_forward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>(                            \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,                          \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_forward_usm_inplace_complex_##EXT(desc, inout, dependencies);                      \
     }                                                                                                   \
                                                                                                         \
     /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
@@ -149,12 +166,20 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
                                                                                                         \
     /*Buffer version*/                                                                                  \
                                                                                                         \
-    /*In-place transform*/                                                                              \
+    /*In-place transform - real*/                                                                       \
+    template <>                                                                                         \
+    ONEMKL_EXPORT void compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(            \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_REAL, 1> & inout) {           \
+        detail::function_tables[get_device_id(desc.get_queue())]                                        \
+            .compute_backward_buffer_inplace_real_##EXT(desc, inout);                                   \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform - complex */                                                                   \
     template <>                                                                                         \
     ONEMKL_EXPORT void compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>(        \
         dft::detail::descriptor<PRECISION, DOMAIN> & desc, sycl::buffer<T_BACKWARD, 1> & inout) {       \
         detail::function_tables[get_device_id(desc.get_queue())]                                        \
-            .compute_backward_buffer_inplace_##EXT(desc, inout);                                        \
+            .compute_backward_buffer_inplace_complex_##EXT(desc, inout);                                \
     }                                                                                                   \
                                                                                                         \
     /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \
@@ -189,14 +214,24 @@ commit_impl* create_commit<precision::DOUBLE, domain::REAL>(
                                                                                                         \
     /*USM version*/                                                                                     \
                                                                                                         \
-    /*In-place transform*/                                                                              \
+    /*In-place transform - real*/                                                                       \
+    template <>                                                                                         \
+    ONEMKL_EXPORT sycl::event                                                                           \
+    compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_REAL>(                               \
+        dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout,                              \
+        const std::vector<sycl::event>& dependencies) {                                                 \
+        return detail::function_tables[get_device_id(desc.get_queue())]                                 \
+            .compute_backward_usm_inplace_real_##EXT(desc, inout, dependencies);                        \
+    }                                                                                                   \
+                                                                                                        \
+    /*In-place transform - complex*/                                                                    \
     template <>                                                                                         \
     ONEMKL_EXPORT sycl::event                                                                           \
     compute_backward<dft::detail::descriptor<PRECISION, DOMAIN>, T_BACKWARD>(                           \
         dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,                          \
         const std::vector<sycl::event>& dependencies) {                                                 \
         return detail::function_tables[get_device_id(desc.get_queue())]                                 \
-            .compute_backward_usm_inplace_##EXT(desc, inout, dependencies);                             \
+            .compute_backward_usm_inplace_complex_##EXT(desc, inout, dependencies);                     \
     }                                                                                                   \
                                                                                                         \
     /*In-place transform, using config_param::COMPLEX_STORAGE=config_value::REAL_REAL data format*/     \

--- a/src/dft/function_table.hpp
+++ b/src/dft/function_table.hpp
@@ -48,82 +48,94 @@ typedef struct {
         oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::DOUBLE,
                                      oneapi::mkl::dft::domain::REAL>& desc);
 
-#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(EXT, PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD) \
-    void (*compute_forward_buffer_inplace_real_##EXT)(                                           \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_REAL, 1> & inout);                                                        \
-    void (*compute_forward_buffer_inplace_complex_##EXT)(                                        \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_BACKWARD, 1> & inout);                                                    \
-    void (*compute_forward_buffer_inplace_split_##EXT)(                                          \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                 \
-    void (*compute_forward_buffer_outofplace_##EXT)(                                             \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_FORWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                     \
-    void (*compute_forward_buffer_outofplace_complex_##EXT)(                                     \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                    \
-    void (*compute_forward_buffer_outofplace_split_##EXT)(                                       \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                        \
-        sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                     \
-    sycl::event (*compute_forward_usm_inplace_real_##EXT)(                                       \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout,          \
-        const std::vector<sycl::event>& dependencies);                                           \
-    sycl::event (*compute_forward_usm_inplace_complex_##EXT)(                                    \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,      \
-        const std::vector<sycl::event>& dependencies);                                           \
-    sycl::event (*compute_forward_usm_inplace_split_##EXT)(                                      \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,       \
-        T_REAL * inout_im, const std::vector<sycl::event>& dependencies);                        \
-    sycl::event (*compute_forward_usm_outofplace_##EXT)(                                         \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * in,          \
-        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                         \
-    sycl::event (*compute_forward_usm_outofplace_complex_##EXT)(                                 \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,         \
-        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                         \
-    sycl::event (*compute_forward_usm_outofplace_split_##EXT)(                                   \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,          \
-        T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                        \
-        const std::vector<sycl::event>& dependencies);                                           \
-    void (*compute_backward_buffer_inplace_real_##EXT)(                                          \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_REAL, 1> & inout);                                                        \
-    void (*compute_backward_buffer_inplace_complex_##EXT)(                                       \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_BACKWARD, 1> & inout);                                                    \
-    void (*compute_backward_buffer_inplace_split_##EXT)(                                         \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                 \
-    void (*compute_backward_buffer_outofplace_##EXT)(                                            \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_FORWARD, 1> & out);                     \
-    void (*compute_backward_buffer_outofplace_complex_##EXT)(                                    \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                    \
-    void (*compute_backward_buffer_outofplace_split_##EXT)(                                      \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                        \
-        sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                     \
-    sycl::event (*compute_backward_usm_inplace_real_##EXT)(                                      \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout,          \
-        const std::vector<sycl::event>& dependencies);                                           \
-    sycl::event (*compute_backward_usm_inplace_complex_##EXT)(                                   \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,      \
-        const std::vector<sycl::event>& dependencies);                                           \
-    sycl::event (*compute_backward_usm_inplace_split_##EXT)(                                     \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,       \
-        T_REAL * inout_im, const std::vector<sycl::event>& dependencies);                        \
-    sycl::event (*compute_backward_usm_outofplace_##EXT)(                                        \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,         \
-        T_FORWARD * out, const std::vector<sycl::event>& dependencies);                          \
-    sycl::event (*compute_backward_usm_outofplace_complex_##EXT)(                                \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,         \
-        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                         \
-    sycl::event (*compute_backward_usm_outofplace_split_##EXT)(                                  \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,          \
-        T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                        \
+#define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(EXT, PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD)   \
+    void (*compute_forward_buffer_inplace_real_##EXT)(                                             \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & inout);                                                          \
+    void (*compute_forward_buffer_inplace_complex_##EXT)(                                          \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_BACKWARD, 1> & inout);                                                      \
+    void (*compute_forward_buffer_inplace_split_##EXT)(                                            \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                   \
+    void (*compute_forward_buffer_outofplace_##EXT)(                                               \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_FORWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                       \
+    void (*compute_forward_buffer_outofplace_real_##EXT)(                                          \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & in, sycl::buffer<T_REAL, 1> & out);                              \
+    void (*compute_forward_buffer_outofplace_complex_##EXT)(                                       \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                      \
+    void (*compute_forward_buffer_outofplace_split_##EXT)(                                         \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                          \
+        sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                       \
+    sycl::event (*compute_forward_usm_inplace_real_##EXT)(                                         \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout,            \
+        const std::vector<sycl::event>& dependencies);                                             \
+    sycl::event (*compute_forward_usm_inplace_complex_##EXT)(                                      \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,        \
+        const std::vector<sycl::event>& dependencies);                                             \
+    sycl::event (*compute_forward_usm_inplace_split_##EXT)(                                        \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,         \
+        T_REAL * inout_im, const std::vector<sycl::event>& dependencies);                          \
+    sycl::event (*compute_forward_usm_outofplace_##EXT)(                                           \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * in,            \
+        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                           \
+    sycl::event (*compute_forward_usm_outofplace_real_##EXT)(                                      \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in, T_REAL * out, \
+        const std::vector<sycl::event>& dependencies);                                             \
+    sycl::event (*compute_forward_usm_outofplace_complex_##EXT)(                                   \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,           \
+        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                           \
+    sycl::event (*compute_forward_usm_outofplace_split_##EXT)(                                     \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,            \
+        T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                          \
+        const std::vector<sycl::event>& dependencies);                                             \
+    void (*compute_backward_buffer_inplace_real_##EXT)(                                            \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & inout);                                                          \
+    void (*compute_backward_buffer_inplace_complex_##EXT)(                                         \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_BACKWARD, 1> & inout);                                                      \
+    void (*compute_backward_buffer_inplace_split_##EXT)(                                           \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                   \
+    void (*compute_backward_buffer_outofplace_##EXT)(                                              \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_FORWARD, 1> & out);                       \
+    void (*compute_backward_buffer_outofplace_real_##EXT)(                                         \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & in, sycl::buffer<T_REAL, 1> & out);                              \
+    void (*compute_backward_buffer_outofplace_complex_##EXT)(                                      \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                      \
+    void (*compute_backward_buffer_outofplace_split_##EXT)(                                        \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                            \
+        sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                          \
+        sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                       \
+    sycl::event (*compute_backward_usm_inplace_real_##EXT)(                                        \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout,            \
+        const std::vector<sycl::event>& dependencies);                                             \
+    sycl::event (*compute_backward_usm_inplace_complex_##EXT)(                                     \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,        \
+        const std::vector<sycl::event>& dependencies);                                             \
+    sycl::event (*compute_backward_usm_inplace_split_##EXT)(                                       \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,         \
+        T_REAL * inout_im, const std::vector<sycl::event>& dependencies);                          \
+    sycl::event (*compute_backward_usm_outofplace_##EXT)(                                          \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,           \
+        T_FORWARD * out, const std::vector<sycl::event>& dependencies);                            \
+    sycl::event (*compute_backward_usm_outofplace_real_##EXT)(                                     \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in, T_REAL * out, \
+        const std::vector<sycl::event>& dependencies);                                             \
+    sycl::event (*compute_backward_usm_outofplace_complex_##EXT)(                                  \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,           \
+        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                           \
+    sycl::event (*compute_backward_usm_outofplace_split_##EXT)(                                    \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,            \
+        T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                          \
         const std::vector<sycl::event>& dependencies);
 
     ONEAPI_MKL_DFT_BACKEND_SIGNATURES(f, oneapi::mkl::dft::detail::precision::SINGLE,

--- a/src/dft/function_table.hpp
+++ b/src/dft/function_table.hpp
@@ -49,21 +49,30 @@ typedef struct {
                                      oneapi::mkl::dft::domain::REAL>& desc);
 
 #define ONEAPI_MKL_DFT_BACKEND_SIGNATURES(EXT, PRECISION, DOMAIN, T_REAL, T_FORWARD, T_BACKWARD) \
-    void (*compute_forward_buffer_inplace_##EXT)(                                                \
+    void (*compute_forward_buffer_inplace_real_##EXT)(                                           \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
-        sycl::buffer<T_FORWARD, 1> & inout);                                                     \
+        sycl::buffer<T_REAL, 1> & inout);                                                        \
+    void (*compute_forward_buffer_inplace_complex_##EXT)(                                        \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_BACKWARD, 1> & inout);                                                    \
     void (*compute_forward_buffer_inplace_split_##EXT)(                                          \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
         sycl::buffer<T_REAL, 1> & inout_re, sycl::buffer<T_REAL, 1> & inout_im);                 \
     void (*compute_forward_buffer_outofplace_##EXT)(                                             \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
         sycl::buffer<T_FORWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                     \
+    void (*compute_forward_buffer_outofplace_complex_##EXT)(                                     \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                    \
     void (*compute_forward_buffer_outofplace_split_##EXT)(                                       \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
         sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                        \
         sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                     \
-    sycl::event (*compute_forward_usm_inplace_##EXT)(                                            \
-        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * inout,       \
+    sycl::event (*compute_forward_usm_inplace_real_##EXT)(                                       \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout,          \
+        const std::vector<sycl::event>& dependencies);                                           \
+    sycl::event (*compute_forward_usm_inplace_complex_##EXT)(                                    \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,      \
         const std::vector<sycl::event>& dependencies);                                           \
     sycl::event (*compute_forward_usm_inplace_split_##EXT)(                                      \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout_re,       \
@@ -71,11 +80,17 @@ typedef struct {
     sycl::event (*compute_forward_usm_outofplace_##EXT)(                                         \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_FORWARD * in,          \
         T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                         \
+    sycl::event (*compute_forward_usm_outofplace_complex_##EXT)(                                 \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,         \
+        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                         \
     sycl::event (*compute_forward_usm_outofplace_split_##EXT)(                                   \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,          \
         T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                        \
         const std::vector<sycl::event>& dependencies);                                           \
-    void (*compute_backward_buffer_inplace_##EXT)(                                               \
+    void (*compute_backward_buffer_inplace_real_##EXT)(                                          \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_REAL, 1> & inout);                                                        \
+    void (*compute_backward_buffer_inplace_complex_##EXT)(                                       \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
         sycl::buffer<T_BACKWARD, 1> & inout);                                                    \
     void (*compute_backward_buffer_inplace_split_##EXT)(                                         \
@@ -84,11 +99,17 @@ typedef struct {
     void (*compute_backward_buffer_outofplace_##EXT)(                                            \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
         sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_FORWARD, 1> & out);                     \
+    void (*compute_backward_buffer_outofplace_complex_##EXT)(                                    \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
+        sycl::buffer<T_BACKWARD, 1> & in, sycl::buffer<T_BACKWARD, 1> & out);                    \
     void (*compute_backward_buffer_outofplace_split_##EXT)(                                      \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc,                          \
         sycl::buffer<T_REAL, 1> & in_re, sycl::buffer<T_REAL, 1> & in_im,                        \
         sycl::buffer<T_REAL, 1> & out_re, sycl::buffer<T_REAL, 1> & out_im);                     \
-    sycl::event (*compute_backward_usm_inplace_##EXT)(                                           \
+    sycl::event (*compute_backward_usm_inplace_real_##EXT)(                                      \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * inout,          \
+        const std::vector<sycl::event>& dependencies);                                           \
+    sycl::event (*compute_backward_usm_inplace_complex_##EXT)(                                   \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * inout,      \
         const std::vector<sycl::event>& dependencies);                                           \
     sycl::event (*compute_backward_usm_inplace_split_##EXT)(                                     \
@@ -97,6 +118,9 @@ typedef struct {
     sycl::event (*compute_backward_usm_outofplace_##EXT)(                                        \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,         \
         T_FORWARD * out, const std::vector<sycl::event>& dependencies);                          \
+    sycl::event (*compute_backward_usm_outofplace_complex_##EXT)(                                \
+        oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_BACKWARD * in,         \
+        T_BACKWARD * out, const std::vector<sycl::event>& dependencies);                         \
     sycl::event (*compute_backward_usm_outofplace_split_##EXT)(                                  \
         oneapi::mkl::dft::detail::descriptor<PRECISION, DOMAIN> & desc, T_REAL * in_re,          \
         T_REAL * in_im, T_REAL * out_re, T_REAL * out_im,                                        \


### PR DESCRIPTION
* More function signatures are exposed for compute_forward and compute_backward.
* MKLGPU did not have its entire interface exposed prior to this PR.

# Description

Please include a summary of the change. Please also include relevant
motivation and context. See
[contribution guidelines](https://github.com/oneapi-src/oneMKL/blob/master/CONTRIBUTING.md)
for more details. If the change fixes an issue not documented in the project's
Github issue tracker, please document all steps necessary to reproduce it.

Fixes # (GitHub issue)

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
- [ ] Have you formatted the code using clang-format?

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
