### PR TITLE
[DFT] Tidy examples code

### DIFF
--- a/examples/dft/compile_time_dispatching/CMakeLists.txt
+++ b/examples/dft/compile_time_dispatching/CMakeLists.txt
@@ -19,11 +19,11 @@
 
 #Build object from all sources
 set(DFTI_CT_SOURCES "")
-if(ENABLE_MKLCPU_BACKEND)
-  list(APPEND DFTI_CT_SOURCES "complex_fwd_usm_mklcpu")
+if(ENABLE_MKLGPU_BACKEND)
+  list(APPEND DFTI_CT_SOURCES "complex_fwd_buffer_mklgpu")
 endif()
 
-if(domain STREQUAL "dft" AND ENABLE_MKLCPU_BACKEND)
+if(domain STREQUAL "dft" AND ENABLE_MKLGPU_BACKEND)
   find_library(OPENCL_LIBRARY NAMES OpenCL)
   message(STATUS "Found OpenCL: ${OPENCL_LIBRARY}")
 endif()
@@ -35,9 +35,9 @@ foreach(dfti_ct_sources ${DFTI_CT_SOURCES})
       PUBLIC ${PROJECT_SOURCE_DIR}/include
       PUBLIC ${CMAKE_BINARY_DIR}/bin
   )
-  if(domain STREQUAL "dft" AND ENABLE_MKLCPU_BACKEND)
-    add_dependencies(example_${domain}_${dfti_ct_sources} onemkl_${domain}_mklcpu)
-    list(APPEND ONEMKL_LIBRARIES_${domain} onemkl_${domain}_mklcpu)
+  if(domain STREQUAL "dft" AND ENABLE_MKLGPU_BACKEND)
+    add_dependencies(example_${domain}_${dfti_ct_sources} onemkl_${domain}_mklgpu)
+    list(APPEND ONEMKL_LIBRARIES_${domain} onemkl_${domain}_mklgpu)
     target_link_libraries(example_${domain}_${dfti_ct_sources} PUBLIC ${OPENCL_LIBRARY})
   endif()
   target_link_libraries(example_${domain}_${dfti_ct_sources} PUBLIC

--- a/examples/dft/compile_time_dispatching/complex_fwd_buffer_mklgpu.cpp
+++ b/examples/dft/compile_time_dispatching/complex_fwd_buffer_mklgpu.cpp
@@ -28,7 +28,7 @@
 #endif
 #include "oneapi/mkl.hpp"
 
-void run_example(const sycl::device& gpu_deviceice) {
+void run_example(const sycl::device& gpu_device) {
     constexpr int N = 10;
 
     // Catch asynchronous exceptions for cpu
@@ -46,7 +46,7 @@ void run_example(const sycl::device& gpu_deviceice) {
         std::exit(2);
     };
 
-    sycl::queue gpu_queue(gpu_deviceice, gpu_error_handler);
+    sycl::queue gpu_queue(gpu_device, gpu_error_handler);
 
     std::vector<std::complex<float>> input_data(N);
     std::vector<std::complex<float>> output_data(N);
@@ -66,7 +66,7 @@ void run_example(const sycl::device& gpu_deviceice) {
     // 3. commit_descriptor (compile_time MKLGPU)
     desc.commit(oneapi::mkl::backend_selector<oneapi::mkl::backend::mklgpu>{ gpu_queue });
 
-    // 5. compute_forward / compute_backward (MKLGPU)
+    // 4. compute_forward / compute_backward (MKLGPU)
     {
         sycl::buffer<std::complex<float>> input_buffer(input_data.data(), sycl::range<1>(N));
         sycl::buffer<std::complex<float>> output_buffer(output_data.data(), sycl::range<1>(N));

--- a/examples/dft/run_time_dispatching/CMakeLists.txt
+++ b/examples/dft/run_time_dispatching/CMakeLists.txt
@@ -20,7 +20,7 @@
 # NOTE: user needs to set env var SYCL_DEVICE_FILTER to use runtime example (no need to specify backend when building with CMake)
 
 # Build object from all example sources
-set(DFT_RT_SOURCES "complex_fwd_usm")
+set(DFT_RT_SOURCES "real_fwd_usm")
 
 # Set up for the right backend for run-time dispatching examples
 # If users build more than one backend (i.e. mklcpu and mklgpu, or mklcpu and CUDA), they may need to
@@ -29,8 +29,7 @@ set(DEVICE_FILTERS "")
 if(ENABLE_MKLCPU_BACKEND)
   list(APPEND DEVICE_FILTERS "cpu")
 endif()
-# RNG only supports mklcpu backend on Windows
-if(UNIX AND ENABLE_MKLGPU_BACKEND)
+if(ENABLE_MKLGPU_BACKEND)
   list(APPEND DEVICE_FILTERS "gpu")
 endif()
 

--- a/examples/dft/run_time_dispatching/real_fwd_usm.cpp
+++ b/examples/dft/run_time_dispatching/real_fwd_usm.cpp
@@ -1,9 +1,25 @@
+/*******************************************************************************
+* Copyright 2022 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions
+* and limitations under the License.
+*
+*
+* SPDX-License-Identifier: Apache-2.0
+*******************************************************************************/
 
 // stl includes
-#include <algorithm>
-#include <cstdlib>
 #include <iostream>
-#include <vector>
+#include <cstdint>
 
 // oneMKL/SYCL includes
 #if __has_include(<sycl/sycl.hpp>)
@@ -11,22 +27,11 @@
 #else
 #include <CL/sycl.hpp>
 #endif
+
 #include "oneapi/mkl.hpp"
 
-// local includes
-#include "example_helper.hpp"
-
-constexpr int SUCCESS = 0;
-constexpr int FAILURE = 1;
-constexpr double TWOPI = 6.2831853071795864769;
-
-void run_uniform_example(const sycl::device& dev) {
-
+void run_example(const sycl::device& dev) {
     int N = 16;
-    int harmonic = 5;
-    int buffer_result = FAILURE;
-    int usm_result = FAILURE;
-    int result = FAILURE;
 
     // Catch asynchronous exceptions
     auto exception_handler = [](sycl::exception_list exceptions) {
@@ -42,33 +47,34 @@ void run_uniform_example(const sycl::device& dev) {
         std::exit(2);
     };
 
-    sycl::queue queue(dev, exception_handler);
-
     std::cout << "DFTI example run_time dispatch" << std::endl;
-    //
-    // Preparation on cpu
-    //
-    sycl::queue cpu_queue(dev, exception_handler);
-    sycl::context cpu_context = cpu_queue.get_context();
-    sycl::event cpu_getrf_done;
 
-    double *x_usm = (double*) malloc_shared(N*2*sizeof(double), cpu_queue.get_device(), cpu_queue.get_context());
+    sycl::queue sycl_queue(dev, exception_handler);
+    auto x_usm = sycl::malloc_shared<float>(N * 2, sycl_queue);
 
-    // enabling
-    // 1. create descriptors 
-    oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::DOUBLE, oneapi::mkl::dft::domain::COMPLEX> desc_vector({N,N});
+    // 1. create descriptors
+    oneapi::mkl::dft::descriptor<oneapi::mkl::dft::precision::SINGLE,
+                                 oneapi::mkl::dft::domain::REAL>
+        desc(N);
 
     // 2. variadic set_value
-    desc_vector.set_value(oneapi::mkl::dft::config_param::BACKWARD_SCALE, (double)(1.0/N));
-    desc_vector.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS, 4);
-    desc_vector.set_value(oneapi::mkl::dft::config_param::BWD_DISTANCE, N);
-    desc_vector.set_value(oneapi::mkl::dft::config_param::PLACEMENT, oneapi::mkl::dft::config_value::NOT_INPLACE);
+    desc.set_value(oneapi::mkl::dft::config_param::FORWARD_SCALE, 1.f / N);
+    desc.set_value(oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS,
+                   static_cast<std::int64_t>(1));
+    desc.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
+                   oneapi::mkl::dft::config_value::INPLACE);
 
-    // 4. commit_descriptor (run_time xPU)
-    desc_vector.commit(cpu_queue);
+    // 4. commit_descriptor (runtime xPU)
+    desc.commit(sycl_queue);
 
-    // 5. compute_forward / compute_backward (CPU)
-    // oneapi::mkl::dft::compute_forward(desc, x_usm);
+    // 5. compute_forward / compute_backward (runtime xPU)
+    auto compute_event = oneapi::mkl::dft::compute_forward(desc, x_usm);
+
+    // Do something with transformed data.
+    compute_event.wait();
+
+    // 6. Free USM allocation.
+    sycl::free(x_usm, sycl_queue);
 }
 
 //
@@ -78,12 +84,11 @@ void print_example_banner() {
     std::cout << "" << std::endl;
     std::cout << "########################################################################"
               << std::endl;
-    std::cout
-        << "# DFTI complex in-place forward transform for USM/Buffer API's example: "
-        << std::endl;
+    std::cout << "# DFTI complex in-place forward transform with USM API example: " << std::endl;
     std::cout << "# " << std::endl;
     std::cout << "# Using APIs:" << std::endl;
-    std::cout << "#   USM/BUffer forward complex in-place" << std::endl;
+    std::cout << "#   USM forward complex in-place" << std::endl;
+    std::cout << "#   Run-time dispatch" << std::endl;
     std::cout << "# " << std::endl;
     std::cout << "# Using single precision (float) data type" << std::endl;
     std::cout << "# " << std::endl;
@@ -119,7 +124,7 @@ int main(int argc, char** argv) {
         }
         std::cout << "Running with single precision real data type:" << std::endl;
 
-        run_uniform_example(my_dev);
+        run_example(my_dev);
         std::cout << "DFIT example ran OK" << std::endl;
     }
     catch (sycl::exception const& e) {

--- a/examples/dft/run_time_dispatching/real_fwd_usm.cpp
+++ b/examples/dft/run_time_dispatching/real_fwd_usm.cpp
@@ -40,14 +40,14 @@ void run_example(const sycl::device& dev) {
                 std::rethrow_exception(e);
             }
             catch (sycl::exception const& e) {
-                std::cerr << "Caught asynchronous SYCL exception during generation:" << std::endl;
+                std::cerr << "Caught asynchronous SYCL exception:" << std::endl;
                 std::cerr << "\t" << e.what() << std::endl;
             }
         }
         std::exit(2);
     };
 
-    std::cout << "DFTI example run_time dispatch" << std::endl;
+    std::cout << "DFT example run_time dispatch" << std::endl;
 
     sycl::queue sycl_queue(dev, exception_handler);
     auto x_usm = sycl::malloc_shared<float>(N * 2, sycl_queue);
@@ -64,16 +64,16 @@ void run_example(const sycl::device& dev) {
     desc.set_value(oneapi::mkl::dft::config_param::PLACEMENT,
                    oneapi::mkl::dft::config_value::INPLACE);
 
-    // 4. commit_descriptor (runtime xPU)
+    // 3. commit_descriptor (runtime dispatch)
     desc.commit(sycl_queue);
 
-    // 5. compute_forward / compute_backward (runtime xPU)
+    // 4. compute_forward / compute_backward (runtime dispatch)
     auto compute_event = oneapi::mkl::dft::compute_forward(desc, x_usm);
 
     // Do something with transformed data.
     compute_event.wait();
 
-    // 6. Free USM allocation.
+    // 5. Free USM allocation.
     sycl::free(x_usm, sycl_queue);
 }
 
@@ -110,7 +110,7 @@ int main(int argc, char** argv) {
     print_example_banner();
 
     try {
-        sycl::device my_dev((sycl::default_selector_v));
+        sycl::device my_dev((sycl::default_selector()));
 
         if (my_dev.is_gpu()) {
             std::cout << "Running DFT complex forward example on GPU device" << std::endl;
@@ -125,7 +125,7 @@ int main(int argc, char** argv) {
         std::cout << "Running with single precision real data type:" << std::endl;
 
         run_example(my_dev);
-        std::cout << "DFIT example ran OK" << std::endl;
+        std::cout << "DFT example ran OK" << std::endl;
     }
     catch (sycl::exception const& e) {
         std::cerr << "Caught synchronous SYCL exception:" << std::endl;
@@ -134,7 +134,7 @@ int main(int argc, char** argv) {
         return 1;
     }
     catch (std::exception const& e) {
-        std::cerr << "Caught std::exception during generation:" << std::endl;
+        std::cerr << "Caught std::exception:" << std::endl;
         std::cerr << "\t" << e.what() << std::endl;
         return 1;
     }


### PR DESCRIPTION
* Remove errors from example code.
* Changes examples to use buffers and USM.
* Changes examples to use real and complex domain DFT.
* Changes compile-time dispatch example to use MKLGPU backend (currently most complete DFT backend).

